### PR TITLE
Add volumes switch on docker rm

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -171,7 +171,8 @@
   "Popup for removing containers."
   'docker-containers-popups
   :man-page "docker-rm"
-  :switches '((?f "Force" "-f"))
+  :switches '((?f "Force" "-f")
+              (?v "Volumes" "-v"))
   :actions  '((?D "Remove" docker-containers-rm-selection)))
 
 (defun docker-containers-refresh ()


### PR DESCRIPTION
Refer: https://docs.docker.com/engine/reference/commandline/rm/

`docker rm -v` removes associated volume (if any)