### PR TITLE
Add url in docker-pkg.el

### DIFF
--- a/docker-pkg.el
+++ b/docker-pkg.el
@@ -3,4 +3,5 @@
     (dash "1.5.0")
     (magit-popup "2.0.50")
     (s "1.9.0")
-    (tle "0.1.0")))
+    (tle "0.1.0"))
+  :url "https://github.com/Silex/docker.el")


### PR DESCRIPTION
This should reflect the url field on the package info, showing something like

```
docker is an installed package.

     Status: Installed in `~/.emacs.d/elpa/docker-20160330.250/' (unsigned).
    Archive: n/a
    Version: 20160330.250
   Requires: emacs-24.4, dash-1.5.0, magit-popup-2.0.50, s-1.9.0, tle-0.1.0
    Summary: Emacs interface to Docker
   Homepage: https://github.com/Silex/docker.el
    Other versions: 20160329.57 (melpa).

[back]

```