### PR TITLE
Adding the ability to map ports to containers when running them.

### DIFF
--- a/docker-images.el
+++ b/docker-images.el
@@ -126,12 +126,28 @@
       (docker "push" args it))
     (tabulated-list-revert)))
 
+(defun docker-images-get-port (portMap)
+  "Get port for image run"
+  (interactive "sProvide a port map pair: ")
+  (if (string= "" portMap)
+      ""
+    (concat "-p " portMap)
+    )
+  )
+
+(defun docker-images-run-port (container args command)
+  (interactive)
+  "Get docker ports"
+  (let ((port (call-interactively 'docker-images-get-port)))
+      (async-shell-command (format "docker run %s %s %s %s" args port container command) (format "*run %s*" container))    
+      ))
+
 (defun docker-images-run-selection (command)
   "Run `docker-run' on the images selection."
   (interactive "sCommand: ")
   (let ((args (s-join " " (docker-images-run-arguments))))
     (--each (docker-images-selection)
-      (async-shell-command (format "docker run %s %s %s" args it command) (format "*run %s*" it)))
+      (docker-images-run-port it args command))
     (tabulated-list-revert)))
 
 (magit-define-popup docker-images-rmi-popup
@@ -163,7 +179,7 @@
   :switches '((?d "Daemonize" "-d")
               (?i "Interactive" "-i")
               (?t "TTY" "-t")
-              (?r "Remove" "--rm"))
+              (?r "Remove" "--rm "))
   :actions  '((?R "Run images" docker-images-run-selection))
   :default-arguments '("-i" "-t" "--rm"))
 

--- a/docker-images.el
+++ b/docker-images.el
@@ -179,7 +179,7 @@
   :switches '((?d "Daemonize" "-d")
               (?i "Interactive" "-i")
               (?t "TTY" "-t")
-              (?r "Remove" "--rm "))
+              (?r "Remove" "--rm"))
   :actions  '((?R "Run images" docker-images-run-selection))
   :default-arguments '("-i" "-t" "--rm"))
 


### PR DESCRIPTION
I'd consider this patch experimental, but I wanted to get the idea out there.

For my typical use case it would be pretty useful to be able to map ports to containers as part of the run command. 
It raises a couple of questions.

1.) Should this be default prompted behavior, or a separate run function ?
2.) As in this example, should I allow mapping a default port, or maybe a space separated list of mappings per container.
3.) Should the command argument be uniformly applied to all selected images, or should we prompt for the command on each container via the same mechanism I'm using for ports.

My emacs-lisp skills are fairly rudimentary so any cleaner way to do this would also be appreciated. If you have strong feelings about which way to go, I'd be happy to rework this patch and redo the pull request.