### PR TITLE
Recreate buffer on table list invocation

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -229,7 +229,7 @@
 (defun docker-containers ()
   "List docker containers."
   (interactive)
-  (pop-to-buffer "*docker-containers*")
+  (docker--recreate-buffer-pop-to "*docker-containers*")
   (docker-containers-mode)
   (docker-containers-refresh)
   (tabulated-list-revert))

--- a/docker-images.el
+++ b/docker-images.el
@@ -199,7 +199,7 @@
 (defun docker-images ()
   "List docker images."
   (interactive)
-  (pop-to-buffer "*docker-images*")
+  (docker--recreate-buffer-pop-to "*docker-images*")
   (docker-images-mode)
   (docker-images-refresh)
   (tabulated-list-revert))

--- a/docker-networks.el
+++ b/docker-networks.el
@@ -105,7 +105,7 @@
 (defun docker-networks ()
   "List docker networks."
   (interactive)
-  (pop-to-buffer "*docker-networks*")
+  (docker--recreate-buffer-pop-to "*docker-networks*")
   (docker-networks-mode)
   (docker-networks-refresh)
   (tabulated-list-revert))

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -37,6 +37,12 @@
     (when (tle-selection-empty-p)
       (tle-mark))))
 
+(defun docker--recreate-buffer-pop-to (buffer-name)
+  (let ((buffer (get-buffer buffer-name)))
+    (if buffer
+      (kill-buffer buffer)))
+  (pop-to-buffer buffer-name))
+
 (provide 'docker-utils)
 
 ;;; docker-utils.el ends here

--- a/docker-volumes.el
+++ b/docker-volumes.el
@@ -103,7 +103,7 @@
 (defun docker-volumes ()
   "List docker volumes."
   (interactive)
-  (pop-to-buffer "*docker-volumes*")
+  (docker--recreate-buffer-pop-to "*docker-volumes*")
   (docker-volumes-mode)
   (docker-volumes-refresh)
   (tabulated-list-revert))


### PR DESCRIPTION
Recreate buffer so that remote invocation is treated correctly.

Closes #26 .