### PR TITLE
Support \t and \n on container info

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -31,16 +31,14 @@
 
 (defun docker-containers-entries ()
   "Return the docker containers data for `tabulated-list-entries'."
-  (let* ((fmt "{{.ID}}\\t{{.Image}}\\t{{.Command}}\\t{{.RunningFor}}\\t{{.Status}}\\t{{.Ports}}\\t{{.Names}}")
+  (let* ((fmt "[{{.ID|json}},{{.Image|json}},{{.Command|json}},{{.RunningFor|json}},{{.Status|json}},{{.Ports|json}},{{.Names|json}}]")
          (data (docker "ps" (format "--format='%s'" fmt) "-a "))
-         (lines (s-split "\n" data t)))
+         (lines (docker-utils-json-read-from-string-multiple data)))
     (-map #'docker-container-parse lines)))
 
 (defun docker-container-parse (line)
   "Convert a LINE from \"docker ps\" to a `tabulated-list-entries' entry."
-  ;; TODO what if command contains a \t ?
-  (let ((data (s-split "\t" line)))
-    (list (nth 6 data) (apply #'vector data))))
+  (list (elt line 6) line))
 
 (defun docker-read-container-name (prompt)
   "Read an container name using PROMPT."

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -24,6 +24,7 @@
 ;;; Code:
 
 (require 'magit-popup)
+(require 'json)
 
 (defun docker-utils-get-marked-items ()
   "Get the marked items data from `tabulated-list-entries'."
@@ -60,6 +61,18 @@
    (if (file-remote-p default-directory)
        (with-parsed-tramp-file-name default-directory nil (concat name " - " host))
      name)))
+
+
+(defun docker-utils-json-read-from-string-multiple (string)
+  "Read the JSON objects contained in STRING and return it."
+  (with-temp-buffer
+    (insert string)
+    (goto-char (point-min))
+    (let (result)
+      (condition-case err
+          (while t
+            (setq result (cons (json-read) result)))
+        (end-of-file (nreverse result))))))
 
 (provide 'docker-utils)
 


### PR DESCRIPTION
Output and parse container information via json so that it can parse \t
and \n characters included in the container information correctly.

Also refer: #2 