### PR TITLE
Use json-mode for docker inspect

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -101,15 +101,8 @@ Remove the volumes associated with the container when VOLUMES is set."
 (defun docker-containers-run-command-on-selection-print (command arguments)
   "Run a docker COMMAND on the containers selection with ARGUMENTS and print"
   (interactive "sCommand: \nsArguments: ")
-  (let ((buffer (get-buffer-create "*docker result*")))
-    (with-current-buffer buffer
-      (erase-buffer))
-    (--each (docker-utils-get-marked-items-ids)
-      (let ((result (docker command arguments it)))
-        (with-current-buffer buffer
-          (goto-char (point-max))
-          (insert result))))
-    (display-buffer buffer)))
+  (docker-utils-run-command-on-selection-print
+   (lambda (id) (docker command arguments id))))
 
 (defmacro docker-containers-create-selection-functions (&rest functions)
   `(progn ,@(--map

--- a/docker-images.el
+++ b/docker-images.el
@@ -106,16 +106,9 @@ Do not delete untagged parents when NO-PRUNE is set."
 (defun docker-images-inspect-selection ()
   "Run `docker-inspect' on the images selection."
   (interactive)
-
-  (let ((buffer (get-buffer-create "*docker result*")))
-    (with-current-buffer buffer
-      (erase-buffer))
-    (--each (docker-utils-get-marked-items-ids)
-      (let ((result (docker "inspect" (s-join " " (docker-images-rmi-arguments)) it)))
-        (with-current-buffer buffer
-          (goto-char (point-max))
-          (insert result))))
-    (display-buffer buffer)))
+  (docker-utils-run-command-on-selection-print
+   (lambda (id) (docker "inspect" id))
+   #'json-mode))
 
 (docker-utils-define-popup docker-images-rmi-popup
   "Popup for removing images."

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -61,6 +61,20 @@
        (with-parsed-tramp-file-name default-directory nil (concat name " - " host))
      name)))
 
+(defun docker-utils-run-command-on-selection-print (command &optional post-process buffer-name)
+  "Run COMMAND on the selections and show the result in BUFFER-NAME.
+Optionally run POST-PROCESS in BUFFER-NAME."
+  (let ((id-list (docker-utils-get-marked-items-ids))
+        (buffer (get-buffer-create (or buffer-name "*docker result*"))))
+    (with-current-buffer buffer
+      (setq buffer-read-only nil)
+      (erase-buffer)
+      (mapc 'insert (mapcar command id-list))
+      (when post-process
+        (funcall post-process))
+      (setq buffer-read-only t))
+    (display-buffer buffer)))
+
 (provide 'docker-utils)
 
 ;;; docker-utils.el ends here


### PR DESCRIPTION
As discussed in #36 with @Yuki-Inoue and @Silex 

* factors out the `docker-utils-run-command-on-selection-print` function
* simplify logic by a double `mapc` instead of iterating in a loop
* make popup buffer read-only (but this may be better done like `magit-popup` does it, at least supporting `q` and `C-g` to exit)
* use it in `docker-images-inspect-selection` with a post-process step to call `json-mode`
* use it in `docker-containers-run-command-on-selection-print`

I personally used `(add-hook 'json-mode-hook 'hs-minor-mode)` rather than adding that to the docker.el code. But if you think we should call it explicitly... let me know.