### PR TITLE
Docker inspect as command

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -200,9 +200,9 @@ Remove the volumes associated with the container when VOLUMES is set."
              (parsed (json-read-from-string json))
              (commands
               (docker-containers-convert-container-info-to-command parsed)))
-        (pop-to-buffer "*docker result*" )
-        (--each commands
-          (insert (combine-and-quote-strings it)))))))
+        (docker-utils-with-result-buffer
+         (--each commands
+           (insert (combine-and-quote-strings it))))))))
 
 (defmacro docker-containers-create-selection-print-functions (&rest functions)
   `(progn ,@(--map

--- a/docker-containers.el
+++ b/docker-containers.el
@@ -178,6 +178,21 @@ Remove the volumes associated with the container when VOLUMES is set."
   (--each (docker-utils-get-marked-items-ids)
     (docker "cp" host-path (concat it ":" container-path))))
 
+(defun docker-containers-inspect-command-selection ()
+  (interactive)
+  (-each (docker-utils-get-marked-items-ids)
+    (lambda (id)
+      (let* ((json (docker "inspect" id))
+             (parsed (json-read-from-string json))
+             (commands (-map
+                        (lambda (container-info)
+                          (list
+                           "docker" "run"
+                           (assoc-default 'Image container-info)
+                           )) parsed )))
+        (--each commands
+          (princ (combine-and-quote-strings it)))))))
+
 (defmacro docker-containers-create-selection-print-functions (&rest functions)
   `(progn ,@(--map
              `(defun ,(intern (format "docker-containers-%s-selection" it)) ()
@@ -211,7 +226,8 @@ Remove the volumes associated with the container when VOLUMES is set."
   "Popup for inspecting containers."
   'docker-containers-popups
   :man-page "docker-inspect"
-  :actions  '((?I "Inspect" docker-containers-inspect-selection)))
+  :actions  '((?I "Inspect" docker-containers-inspect-selection)
+              (?C "As Command" docker-containers-inspect-command-selection)))
 
 (docker-utils-define-popup docker-containers-logs-popup
   "Popup for showing containers logs."

--- a/docker-containers.el
+++ b/docker-containers.el
@@ -200,8 +200,9 @@ Remove the volumes associated with the container when VOLUMES is set."
              (parsed (json-read-from-string json))
              (commands
               (docker-containers-convert-container-info-to-command parsed)))
+        (pop-to-buffer "*docker result*" )
         (--each commands
-          (princ (combine-and-quote-strings it)))))))
+          (insert (combine-and-quote-strings it)))))))
 
 (defmacro docker-containers-create-selection-print-functions (&rest functions)
   `(progn ,@(--map


### PR DESCRIPTION
From the `docker inspect` result, create the shell-command which would reproduce the original `docker run` command.