### PR TITLE
support old docker where json template not working

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -37,7 +37,7 @@
 
 (defun docker-containers-entries ()
   "Return the docker containers data for `tabulated-list-entries'."
-  (let* ((fmt "[{{json .ID}},{{json .Image}},{{json .Command}},{{json .RunningFor}},{{json .Status}},{{json .Ports}},{{json .Names}}]")
+  (let* ((fmt (docker-utils-json-format "[{{.ID}},{{.Image}},{{.Command}},{{.RunningFor}},{{.Status}},{{.Ports}},{{.Names}}]"))
          (data (docker "ps" (format "--format=\"%s\"" fmt) (when docker-containers-show-all "-a ")))
          (lines (s-split "\n" data t)))
     (-map #'docker-container-parse lines)))

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -25,6 +25,20 @@
 
 (require 'magit-popup)
 
+;;;###autoload
+(defun docker-version (&optional called-interactively)
+  "Print or return the docker version as as string, depending on CALLED-INTERACTIVELY."
+  (interactive "p")
+  (let ((version (s-trim (shell-command-to-string "docker version --format '{{.Server.Version}}'"))))
+    (when called-interactively
+      (message "The docker version is %s" version))
+    version))
+
+(defun docker-utils-json-format (fmt)
+  "Formats FMT to return the appropriate JSON data."
+  (let ((replacement (if (version< (docker-version) "1.12.0") "\\1|json" "json \\1")))
+    (replace-regexp-in-string "\\(\\.[_[:alnum:]]+\\)" replacement fmt t)))
+
 (defun docker-utils-get-marked-items ()
   "Get the marked items data from `tabulated-list-entries'."
   (save-excursion


### PR DESCRIPTION
Old docker does not support `json` function template.
For such case, use the old logic of `\t` based formatting for docker-container.