### PR TITLE
Handle json error on docker-container

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -44,7 +44,11 @@
 
 (defun docker-container-parse (line)
   "Convert a LINE from \"docker ps\" to a `tabulated-list-entries' entry."
-  (let ((data (json-read-from-string line)))
+  (let (data)
+    (condition-case err
+        (setq data (json-read-from-string line))
+      (json-readtable-error
+       (error "could not read following string as json:\n%s" line)))
     (list (aref data 6) data)))
 
 (defun docker-read-container-name (prompt)


### PR DESCRIPTION

Lets say we are in an environment where docker must be `sudo docker`.
(Default if docker is installed via ubuntu apt-get.)

Currently, if there is error on json parsing at docker-container,
the docker.el just tells (the `*Messages*` buffer extracted):

```
docker ps --format="[{{json .ID}},{{json .Image}},{{json .Command}},{{json .RunningFor}},{{json .Status}},{{json .Ports}},{{json .Names}}]" -a
json-read: JSON readtable error
```

With this fix, docker.el tells:

```
docker ps --format="[{{json .ID}},{{json .Image}},{{json .Command}},{{json .RunningFor}},{{json .Status}},{{json .Ports}},{{json .Names}}]" -a
condition-case: could not read following string as json:
Cannot connect to the Docker daemon. Is the docker daemon running on this host?
```

Which makes it easier to findout what to do.
