### PR TITLE
[Fix #43] Logical sort for date and size in table views

### DIFF
--- a/docker-engine-api.el
+++ b/docker-engine-api.el
@@ -1,0 +1,62 @@
+;;; docker-engine-api.el --- operating system specific utilities
+
+;; Author: Philippe Vaucher <philippe.vaucher@gmail.com>
+;;         Yuki Inoue <inouetakahiroki@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'request)
+
+(defun docker-engine-api-get (path params parser)
+  "Get PATH from Docker Engine API and parse with PARSER."
+  (let (result)
+    (pcase system-type
+      ('windows-nt (request
+                    (concat "http://localhost:2375/v1.26" path)
+                    :type "GET"
+                    :params params
+                    :sync t
+                    :timeout 5
+                    :parser parser
+                    :success (cl-function
+                              (lambda (&key data &allow-other-keys)
+                                (setq result data)
+                                (let ((inhibit-message t))
+                                  (message "Docker Engine API: %s" data))))))
+      (_           (request
+                    (concat "http:/v1.26" path)
+                    :unix-socket "/var/run/docker.sock"
+                    :type "GET"
+                    :params params
+                    :sync t
+                    :timeout 5
+                    :parser parser
+                    :success (cl-function
+                              (lambda (&key data &allow-other-keys)
+                                (setq result data)
+                                (let ((inhibit-message t))
+                                  (message "Docker Engine API: %s" data)))))))
+    result))
+
+(provide 'docker-engine-api)
+
+;;; docker-engine-api.el ends here

--- a/docker.el
+++ b/docker.el
@@ -4,7 +4,7 @@
 ;; URL: https://github.com/Silex/docker.el
 ;; Keywords: filename, convenience
 ;; Version: 0.5.2
-;; Package-Requires: ((emacs "24.4") (dash "2.12.1") (docker-tramp "0.1") (magit-popup "2.6.0") (s "1.11.0") (tablist "0.70") (json-mode "1.7.0"))
+;; Package-Requires: ((emacs "24.4") (dash "2.12.1") (docker-tramp "0.1") (magit-popup "2.6.0") (s "1.11.0") (tablist "0.70") (json-mode "1.7.0") (request "0.3.0")
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This is a proof of concept that cleans up the `images` and `containers` tables, and makes the size and date columns sort more naturally. This is achieved by issuing HTTP requests directly on the Docker Engine API endpoint on the local machine, as mentioned in #43.

Limitations:

* As implemented, this will not work on remote machines... i.e. whereas in theory you can use environment variables to get the `docker` command to talk to remote API endpoints, this isn't yet implemented for these table queries. In theory it should be possible though

* I don't have the equipment to test on Windows, so what is written for Windows may need a little more work.

<img width="636" alt="screen shot 2018-02-05 at 6 44 30 pm" src="https://user-images.githubusercontent.com/2460918/35839689-9b2db988-0aa6-11e8-8ce7-d82d28372a2f.png">

