### PR TITLE
Proposal: Run docker logs in compile mode if only one container is selected.

### DIFF
--- a/docker-containers.el
+++ b/docker-containers.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'docker-process)
+(require 'docker-logs)
 (require 'docker-utils)
 (require 'magit-popup)
 (require 'tablist)
@@ -278,6 +279,18 @@ Remove the volumes associated with the container when VOLUMES is set."
                                                                   (s-join " " ,(list (intern (format "docker-containers-%s-arguments" it))))))
              functions)))
 
+(defun docker-containers-logs-selection ()
+  "Run docker-logs on the containers selection. If only one
+container selected run it in compile-mode."
+  (interactive)
+  (let* ((id-list (docker-utils-get-marked-items-ids))
+         (containers (mapconcat 'identity id-list " "))
+         (docker-logs-command (format "docker logs %s" containers)))
+    (if (= 1 (length id-list))
+        (docker-logs-show (car id-list))
+      (docker-containers-run-command-on-selection-print "logs"
+                                                        (s-join " " (docker-containers-logs-arguments))))))
+
 (docker-containers-create-selection-functions
   start
   stop
@@ -287,7 +300,7 @@ Remove the volumes associated with the container when VOLUMES is set."
   rm
   kill)
 
-(docker-containers-create-selection-print-functions inspect logs diff)
+(docker-containers-create-selection-print-functions inspect diff)
 
 (docker-utils-define-popup docker-containers-diff-popup
   "Popup for showing containers diffs."

--- a/docker-logs.el
+++ b/docker-logs.el
@@ -1,0 +1,17 @@
+;;; docker-logs.el --- Docker logs specific functionality
+(require 'compile)
+
+(define-compilation-mode docker-logs-mode "docker logs"
+  "Docker logs mode"
+  (set (make-local-variable 'compilation-highlight-regexp) nil)
+  (set (make-local-variable 'compilation-error-regexp-alist) nil)
+  (set (make-local-variable 'compilation-error-regexp-alist-alist) nil))
+
+
+(defun docker-logs-show (id)
+  "Run docker logs in compilation mode."
+  (let ((docker-logs-command (format "docker logs %s" id)))
+    (compilation-start docker-logs-command #'docker-logs-mode
+                       `(lambda (mode-name) ,(concat "*" docker-logs-command "*")))))
+
+(provide 'docker-logs)


### PR DESCRIPTION
Often when I'm debugging a background container I send some data through a shell and then I need to see the output of docker logs. It's somewhat cumbersome that if I want to see the logs again I have to go back to the containers window and type "L L". It would be much easier to just type "g" in the same buffer that you see the logs, just what compile-mode provides.

Since the functionality of compile-mode is designed for the output of just one command, I made this so if you select just one container you get compile-mode. Otherwise, you get get the same result buffer so this probably won't break anything (unless you actually like the docker-result window better that a compile-mode). One other improvement could be a variable that controls this behavior.

I could develop this so we have a "docker-logs-mode" that derives from compile-mode and adapt it more specific needs. Just like ag-mode and other do. I just want to see what the community has to say about  this.