### PR TITLE
Fix image run command not respecting run-as-root

### DIFF
--- a/docker-images.el
+++ b/docker-images.el
@@ -113,9 +113,13 @@ Do not delete untagged parents when NO-PRUNE is set."
   (let* ((popup-args (docker-images-run-arguments))
          (last-item (-last-item popup-args))
          (has-command (s-contains? "--command" last-item))
-         (docker-args (if has-command (-slice popup-args 0 -1) popup-args)))
+         (docker-args (if has-command (-slice popup-args 0 -1) popup-args))
+         (default-directory (if (and docker-run-as-root
+                                     (not (file-remote-p default-directory)))
+                                "/sudo::"
+                              default-directory)))
     (--each (docker-utils-get-marked-items-ids)
-      (let ((command-args `("docker" "run" ,@docker-args ,it)))
+      (let ((command-args `(,docker-command "run" ,@docker-args ,it)))
         (when has-command
           (add-to-list 'command-args (s-chop-prefix "--command " last-item) t))
         (async-shell-command (s-join " " command-args) (format "*run %s*" it))))


### PR DESCRIPTION
Hi there!

I ran into what seems to be a bug with the `docker-run-as-root` variable while trying to use the run command on images. Red Hat derived distros [have to run Docker with sudo](http://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/) and I noticed `docker.el` was consistently running the plain docker command despite having it set to always run as root.

I'm new-ish to ELisp, so please don't hesitate to suggest corrections or style changes if it's not inline with what you'd like.

I'll include some screen captures here as proof that the change has worked for me. I would be happy to provide any other proof/assistance as needed.

Here's a `screenfetch` for information about my system:
![2018-05-21-142911_3839x2159_scrot](https://user-images.githubusercontent.com/5441516/40324740-6ebe6088-5d07-11e8-90ab-414ca7c65bec.png)

Here you can see that I'm about to run a container based on the `httpd` image. It will be named "cool-server-6":
![2018-05-21-143240_1914x2139_scrot](https://user-images.githubusercontent.com/5441516/40324800-a8277a4e-5d07-11e8-8001-82cd0981eb9d.png)

At the bottom here you can see that Emacs is prompting me for my password:
![2018-05-21-143251_1910x2159_scrot](https://user-images.githubusercontent.com/5441516/40324849-ce611166-5d07-11e8-9bb8-3a0c5ec2146c.png)

Here's a successful run, the ID of the new container is over on the right:
![2018-05-21-143310_3839x2159_scrot](https://user-images.githubusercontent.com/5441516/40324889-f2331fbc-5d07-11e8-96ec-70ed215ba8ba.png)

And finally here's that container running. You can compare the name and ID and see that it's the same as the one started with the run command:
![2018-05-21-143336_2678x416_scrot](https://user-images.githubusercontent.com/5441516/40324924-1911c200-5d08-11e8-8426-6a915c48145a.png)

Cheers :beers: !