### PR TITLE
Add `All` actions.

### DIFF
--- a/docker-compose.el
+++ b/docker-compose.el
@@ -96,7 +96,7 @@
 
 ;;;###autoload
 (defun docker-compose-build (services args)
-  "Run \"docker-compose build\" using ARGS."
+  "Run \"docker-compose build SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-build-arguments)))
   (docker-compose--run-async "build" args services))
 
@@ -108,55 +108,55 @@
 
 ;;;###autoload
 (defun docker-compose-logs (services args)
-  "Run \"docker-compose logs\" using ARGS."
+  "Run \"docker-compose logs SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-logs-arguments)))
   (docker-compose--run-async "logs" args services))
 
 ;;;###autoload
 (defun docker-compose-pull (services args)
-  "Run \"docker-compose pull\" using ARGS."
+  "Run \"docker-compose pull SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-pull-arguments)))
   (docker-compose--run "pull" args services))
 
 ;;;###autoload
 (defun docker-compose-push (services args)
-  "Run \"docker-compose push\" using ARGS."
+  "Run \"docker-compose push SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-push-arguments)))
   (docker-compose--run "push" args services))
 
 ;;;###autoload
 (defun docker-compose-restart (services args)
-  "Run \"docker-compose restart\" using ARGS."
+  "Run \"docker-compose restart SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-restart-arguments)))
   (docker-compose--run "restart" args services))
 
 ;;;###autoload
 (defun docker-compose-rm (services args)
-  "Run \"docker-compose rm\" using ARGS."
+  "Run \"docker-compose rm SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-rm-arguments)))
   (docker-compose--run "rm" args services))
 
 ;;;###autoload
 (defun docker-compose-run (service command args)
-  "Run \"docker-compose run\" using ARGS."
+  "Run \"docker-compose run SERVICE COMMAND\" using ARGS."
   (interactive (list (docker-compose-read-service-name) (read-string "Command: ") (docker-compose-run-arguments)))
   (docker-compose--run-async "run" args service command))
 
 ;;;###autoload
 (defun docker-compose-start (services args)
-  "Run \"docker-compose start\" using ARGS."
+  "Run \"docker-compose start SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-start-arguments)))
   (docker-compose--run "start" args services))
 
 ;;;###autoload
 (defun docker-compose-stop (services args)
-  "Run \"docker-compose stop\" using ARGS."
+  "Run \"docker-compose stop SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-stop-arguments)))
   (docker-compose--run "stop" args services))
 
 ;;;###autoload
 (defun docker-compose-up (services args)
-  "Run \"docker-compose up\" using ARGS."
+  "Run \"docker-compose up SERVICES\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-up-arguments)))
   (docker-compose--run-async "up" args services))
 

--- a/docker-compose.el
+++ b/docker-compose.el
@@ -160,6 +160,66 @@
   (interactive (list (docker-compose-read-services-names) (docker-compose-up-arguments)))
   (docker-compose--run-async "up" args services))
 
+;;;###autoload
+(defun docker-compose-build-all (args)
+  "Run \"docker-compose build\" using ARGS."
+  (interactive (list (docker-compose-build-arguments)))
+  (docker-compose--run-async "build" args))
+
+;;;###autoload
+(defun docker-compose-create-all (args)
+  "Run \"docker-compose create\" using ARGS."
+  (interactive (list (docker-compose-create-arguments)))
+  (docker-compose--run-async "create" args))
+
+;;;###autoload
+(defun docker-compose-logs-all (args)
+  "Run \"docker-compose logs\" using ARGS."
+  (interactive (list (docker-compose-logs-arguments)))
+  (docker-compose--run-async "logs" args))
+
+;;;###autoload
+(defun docker-compose-pull-all (args)
+  "Run \"docker-compose pull\" using ARGS."
+  (interactive (list (docker-compose-pull-arguments)))
+  (docker-compose--run "pull" args))
+
+;;;###autoload
+(defun docker-compose-push-all (args)
+  "Run \"docker-compose push\" using ARGS."
+  (interactive (list (docker-compose-push-arguments)))
+  (docker-compose--run "push" args))
+
+;;;###autoload
+(defun docker-compose-restart-all (args)
+  "Run \"docker-compose restart\" using ARGS."
+  (interactive (list (docker-compose-restart-arguments)))
+  (docker-compose--run "restart" args))
+
+;;;###autoload
+(defun docker-compose-rm-all (args)
+  "Run \"docker-compose rm\" using ARGS."
+  (interactive (list (docker-compose-rm-arguments)))
+  (docker-compose--run "rm" args))
+
+;;;###autoload
+(defun docker-compose-start-all (args)
+  "Run \"docker-compose start\" using ARGS."
+  (interactive (list (docker-compose-start-arguments)))
+  (docker-compose--run "start" args))
+
+;;;###autoload
+(defun docker-compose-stop-all (args)
+  "Run \"docker-compose stop\" using ARGS."
+  (interactive (list (docker-compose-stop-arguments)))
+  (docker-compose--run "stop" args))
+
+;;;###autoload
+(defun docker-compose-up-all (args)
+  "Run \"docker-compose up\" using ARGS."
+  (interactive (list (docker-compose-up-arguments)))
+  (docker-compose--run-async "up" args))
+
 (magit-define-popup docker-compose-build-popup
   "Popup for \"docker-compose build\"."
   'docker-compose
@@ -170,7 +230,8 @@
               (?p "Attempt to pull a newer version of the image" "--pull"))
   :options  '((?b "Build argument" "--build-arg ")
               (?m "Memory limit" "--memory "))
-  :actions  '((?B "Build" docker-compose-build)))
+  :actions  '((?B "Build" docker-compose-build)
+              (?A "Build All" docker-compose-build-all)))
 
 (magit-define-popup docker-compose-create-popup
   "Popup for \"docker-compose create\"."
@@ -179,7 +240,8 @@
   :switches '((?b "Build" "--build")
               (?f "Force recreate" "--force-recreate")
               (?n "No recreate" "--no-recreate"))
-  :actions  '((?C "Create" docker-compose-create)))
+  :actions  '((?C "Create" docker-compose-create)
+              (?A "Create All" docker-compose-create-all)))
 
 (magit-define-popup docker-compose-logs-popup
   "Popup for \"docker-compose logs\"."
@@ -189,7 +251,8 @@
               (?n "No color" "--no-color")
               (?t "Timestamps" "--timestamps"))
   :options  '((?T "Tail" "--tail="))
-  :actions  '((?L "Logs" docker-compose-logs)))
+  :actions  '((?L "Logs" docker-compose-logs)
+              (?A "Logs All" docker-compose-logs-all)))
 
 (magit-define-popup docker-compose-pull-popup
   "Popup for \"docker-compose pull\"."
@@ -198,21 +261,24 @@
   :switches '((?d "Include dependencies" "--include-deps")
               (?i "Ignore pull failures" "--ignore-pull-failures")
               (?n "No parallel" "--no-parallel"))
-  :actions  '((?F "Pull" docker-compose-pull)))
+  :actions  '((?F "Pull" docker-compose-pull)
+              (?A "Pull All" docker-compose-pull-all)))
 
 (magit-define-popup docker-compose-push-popup
   "Popup for \"docker-compose push\"."
   'docker-compose
   :man-page "docker-compose push"
   :switches '((?i "Ignore push failures" "--ignore-push-failures"))
-  :actions  '((?P "Push" docker-compose-push)))
+  :actions  '((?P "Push" docker-compose-push)
+              (?A "Push All" docker-compose-push-all)))
 
 (magit-define-popup docker-compose-restart-popup
   "Popup for \"docker-compose restart\"."
   'docker-compose
   :man-page "docker-compose restart"
   :options  '((?t "Timeout" "--timeout "))
-  :actions  '((?R "Restart" docker-compose-restart)))
+  :actions  '((?R "Restart" docker-compose-restart)
+              (?A "Restart All" docker-compose-restart-all)))
 
 (magit-define-popup docker-compose-rm-popup
   "Popup for \"docker-compose rm\"."
@@ -221,7 +287,8 @@
   :switches '((?f "Force" "--force")
               (?s "Stop" "--stop")
               (?v "Remove anonymous volumes" "-v"))
-  :actions  '((?D "Remove" docker-compose-rm)))
+  :actions  '((?D "Remove" docker-compose-rm)
+              (?A "Remove All" docker-compose-rm-all)))
 
 (magit-define-popup docker-compose-run-popup
   "Popup for \"docker-compose run\"."
@@ -244,14 +311,16 @@
   "Popup for \"docker-compose start\"."
   'docker-compose
   :man-page "docker-compose start"
-  :actions  '((?S "Start" docker-compose-start)))
+  :actions  '((?S "Start" docker-compose-start)
+              (?A "Start All" docker-compose-start-all)))
 
 (magit-define-popup docker-compose-stop-popup
   "Popup for \"docker-compose stop\"."
   'docker-compose
   :man-page "docker-compose stop"
   :options  '((?t "Timeout" "--timeout "))
-  :actions  '((?O "Stop" docker-compose-stop)))
+  :actions  '((?O "Stop" docker-compose-stop)
+              (?A "Stop All" docker-compose-stop-all)))
 
 (magit-define-popup docker-compose-up-popup
   "Popup for \"docker-compose up\"."
@@ -264,7 +333,8 @@
               (?r "Remove orphans" "--remove-orphans"))
   :options  '((?c "Scale" "--scale ")
               (?t "Timeout" "--timeout "))
-  :actions  '((?U "Up" docker-compose-up)))
+  :actions  '((?U "Up" docker-compose-up)
+              (?A "Up All" docker-compose-up-all)))
 
 ;;;###autoload (autoload 'docker-compose "docker-compose" nil t)
 (magit-define-popup docker-compose

--- a/docker-compose.el
+++ b/docker-compose.el
@@ -82,6 +82,10 @@
   "Return the list of services."
   (s-split "\n" (docker-compose--run "config" "--services") t))
 
+(defun docker-compose-read-services-names ()
+  "Read the services names."
+  (read-string (format "Services (%s or RET): " (s-join "," (docker-compose-services)))))
+
 (defun docker-compose-read-service-name ()
   "Read one service name."
   (completing-read "Service: " (docker-compose-services)))
@@ -91,40 +95,40 @@
   (completing-read "Level: " '(DEBUG INFO WARNING ERROR CRITICAL)))
 
 ;;;###autoload
-(defun docker-compose-build (args)
+(defun docker-compose-build (services args)
   "Run \"docker-compose build\" using ARGS."
-  (interactive (list (docker-compose-build-arguments)))
-  (docker-compose--run-async "build" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-build-arguments)))
+  (docker-compose--run-async "build" args services))
 
 ;;;###autoload
-(defun docker-compose-logs (args)
+(defun docker-compose-logs (services args)
   "Run \"docker-compose logs\" using ARGS."
-  (interactive (list (docker-compose-logs-arguments)))
-  (docker-compose--run-async "logs" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-logs-arguments)))
+  (docker-compose--run-async "logs" args services))
 
 ;;;###autoload
-(defun docker-compose-pull (args)
+(defun docker-compose-pull (services args)
   "Run \"docker-compose pull\" using ARGS."
-  (interactive (list (docker-compose-pull-arguments)))
-  (docker-compose--run "pull" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-pull-arguments)))
+  (docker-compose--run "pull" args services))
 
 ;;;###autoload
-(defun docker-compose-push (args)
+(defun docker-compose-push (services args)
   "Run \"docker-compose push\" using ARGS."
-  (interactive (list (docker-compose-push-arguments)))
-  (docker-compose--run "push" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-push-arguments)))
+  (docker-compose--run "push" args services))
 
 ;;;###autoload
-(defun docker-compose-restart (args)
+(defun docker-compose-restart (services args)
   "Run \"docker-compose restart\" using ARGS."
-  (interactive (list (docker-compose-restart-arguments)))
-  (docker-compose--run "restart" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-restart-arguments)))
+  (docker-compose--run "restart" args services))
 
 ;;;###autoload
-(defun docker-compose-rm (args)
+(defun docker-compose-rm (services args)
   "Run \"docker-compose rm\" using ARGS."
-  (interactive (list (docker-compose-rm-arguments)))
-  (docker-compose--run "rm" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-rm-arguments)))
+  (docker-compose--run "rm" args services))
 
 ;;;###autoload
 (defun docker-compose-run (service command args)
@@ -133,22 +137,22 @@
   (docker-compose--run-async "run" args service command))
 
 ;;;###autoload
-(defun docker-compose-start (args)
+(defun docker-compose-start (services args)
   "Run \"docker-compose start\" using ARGS."
-  (interactive (list (docker-compose-start-arguments)))
-  (docker-compose--run "start" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-start-arguments)))
+  (docker-compose--run "start" args services))
 
 ;;;###autoload
-(defun docker-compose-stop (args)
+(defun docker-compose-stop (services args)
   "Run \"docker-compose stop\" using ARGS."
-  (interactive (list (docker-compose-stop-arguments)))
-  (docker-compose--run "stop" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-stop-arguments)))
+  (docker-compose--run "stop" args services))
 
 ;;;###autoload
-(defun docker-compose-up (args)
+(defun docker-compose-up (services args)
   "Run \"docker-compose up\" using ARGS."
-  (interactive (list (docker-compose-up-arguments)))
-  (docker-compose--run-async "up" args))
+  (interactive (list (docker-compose-read-services-names) (docker-compose-up-arguments)))
+  (docker-compose--run-async "up" args services))
 
 (magit-define-popup docker-compose-build-popup
   "Popup for \"docker-compose build\"."
@@ -159,8 +163,7 @@
               (?n "Do not use cache" "--no-cache")
               (?p "Attempt to pull a newer version of the image" "--pull"))
   :options  '((?b "Build argument" "--build-arg ")
-              (?m "Memory limit" "--memory ")
-              (?s "Services" ""))
+              (?m "Memory limit" "--memory "))
   :actions  '((?B "Build" docker-compose-build)))
 
 (magit-define-popup docker-compose-create-popup
@@ -170,7 +173,6 @@
   :switches '((?b "Build" "--build")
               (?f "Force recreate" "--force-recreate")
               (?n "No recreate" "--no-recreate"))
-  :options  '((?s "Services" ""))
   :actions  '((?C "Create" docker-compose-create)))
 
 (magit-define-popup docker-compose-logs-popup
@@ -180,8 +182,7 @@
   :switches '((?f "Follow" "--follow")
               (?n "No color" "--no-color")
               (?t "Timestamps" "--timestamps"))
-  :options  '((?T "Tail" "--tail=")
-              (?s "Services" ""))
+  :options  '((?T "Tail" "--tail="))
   :actions  '((?L "Logs" docker-compose-logs)))
 
 (magit-define-popup docker-compose-pull-popup
@@ -191,7 +192,6 @@
   :switches '((?d "Include dependencies" "--include-deps")
               (?i "Ignore pull failures" "--ignore-pull-failures")
               (?n "No parallel" "--no-parallel"))
-  :options  '((?s "Services" ""))
   :actions  '((?F "Pull" docker-compose-pull)))
 
 (magit-define-popup docker-compose-push-popup
@@ -199,15 +199,13 @@
   'docker-compose
   :man-page "docker-compose push"
   :switches '((?i "Ignore push failures" "--ignore-push-failures"))
-  :options  '((?s "Services" ""))
   :actions  '((?P "Push" docker-compose-push)))
 
 (magit-define-popup docker-compose-restart-popup
   "Popup for \"docker-compose restart\"."
   'docker-compose
   :man-page "docker-compose restart"
-  :options  '((?t "Timeout" "--timeout ")
-              (?s "Services" ""))
+  :options  '((?t "Timeout" "--timeout "))
   :actions  '((?R "Restart" docker-compose-restart)))
 
 (magit-define-popup docker-compose-rm-popup
@@ -217,7 +215,6 @@
   :switches '((?f "Force" "--force")
               (?s "Stop" "--stop")
               (?v "Remove anonymous volumes" "-v"))
-  :options  '((?s "Services" ""))
   :actions  '((?D "Remove" docker-compose-rm)))
 
 (magit-define-popup docker-compose-run-popup
@@ -241,15 +238,13 @@
   "Popup for \"docker-compose start\"."
   'docker-compose
   :man-page "docker-compose start"
-  :options  '((?s "Services" ""))
   :actions  '((?S "Start" docker-compose-start)))
 
 (magit-define-popup docker-compose-stop-popup
   "Popup for \"docker-compose stop\"."
   'docker-compose
   :man-page "docker-compose stop"
-  :options  '((?t "Timeout" "--timeout ")
-              (?s "Services" ""))
+  :options  '((?t "Timeout" "--timeout "))
   :actions  '((?O "Stop" docker-compose-stop)))
 
 (magit-define-popup docker-compose-up-popup
@@ -262,8 +257,7 @@
               (?n "No deps" "--no-deps")
               (?r "Remove orphans" "--remove-orphans"))
   :options  '((?c "Scale" "--scale ")
-              (?t "Timeout" "--timeout ")
-              (?s "Services" ""))
+              (?t "Timeout" "--timeout "))
   :actions  '((?U "Up" docker-compose-up)))
 
 ;;;###autoload (autoload 'docker-compose "docker-compose" nil t)

--- a/docker-compose.el
+++ b/docker-compose.el
@@ -101,6 +101,12 @@
   (docker-compose--run-async "build" args services))
 
 ;;;###autoload
+(defun docker-compose-create (services args)
+  "Run \"docker-compose create SERVICES\" using ARGS."
+  (interactive (list (docker-compose-read-services-names) (docker-compose-create-arguments)))
+  (docker-compose--run-async "create" args services))
+
+;;;###autoload
 (defun docker-compose-logs (services args)
   "Run \"docker-compose logs\" using ARGS."
   (interactive (list (docker-compose-read-services-names) (docker-compose-logs-arguments)))

--- a/docker-compose.el
+++ b/docker-compose.el
@@ -96,43 +96,43 @@
 
 ;;;###autoload
 (defun docker-compose-build (services args)
-  "Run \"docker-compose build SERVICES\" using ARGS."
+  "Run \"docker-compose build ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-build-arguments)))
   (docker-compose--run-async "build" args services))
 
 ;;;###autoload
 (defun docker-compose-create (services args)
-  "Run \"docker-compose create SERVICES\" using ARGS."
+  "Run \"docker-compose create ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-create-arguments)))
   (docker-compose--run-async "create" args services))
 
 ;;;###autoload
 (defun docker-compose-logs (services args)
-  "Run \"docker-compose logs SERVICES\" using ARGS."
+  "Run \"docker-compose logs ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-logs-arguments)))
   (docker-compose--run-async "logs" args services))
 
 ;;;###autoload
 (defun docker-compose-pull (services args)
-  "Run \"docker-compose pull SERVICES\" using ARGS."
+  "Run \"docker-compose pull ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-pull-arguments)))
   (docker-compose--run "pull" args services))
 
 ;;;###autoload
 (defun docker-compose-push (services args)
-  "Run \"docker-compose push SERVICES\" using ARGS."
+  "Run \"docker-compose push ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-push-arguments)))
   (docker-compose--run "push" args services))
 
 ;;;###autoload
 (defun docker-compose-restart (services args)
-  "Run \"docker-compose restart SERVICES\" using ARGS."
+  "Run \"docker-compose restart ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-restart-arguments)))
   (docker-compose--run "restart" args services))
 
 ;;;###autoload
 (defun docker-compose-rm (services args)
-  "Run \"docker-compose rm SERVICES\" using ARGS."
+  "Run \"docker-compose rm ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-rm-arguments)))
   (docker-compose--run "rm" args services))
 
@@ -144,79 +144,79 @@
 
 ;;;###autoload
 (defun docker-compose-start (services args)
-  "Run \"docker-compose start SERVICES\" using ARGS."
+  "Run \"docker-compose start ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-start-arguments)))
   (docker-compose--run "start" args services))
 
 ;;;###autoload
 (defun docker-compose-stop (services args)
-  "Run \"docker-compose stop SERVICES\" using ARGS."
+  "Run \"docker-compose stop ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-stop-arguments)))
   (docker-compose--run "stop" args services))
 
 ;;;###autoload
 (defun docker-compose-up (services args)
-  "Run \"docker-compose up SERVICES\" using ARGS."
+  "Run \"docker-compose up ARGS SERVICES\"."
   (interactive (list (docker-compose-read-services-names) (docker-compose-up-arguments)))
   (docker-compose--run-async "up" args services))
 
 ;;;###autoload
 (defun docker-compose-build-all (args)
-  "Run \"docker-compose build\" using ARGS."
+  "Run \"docker-compose build ARGS\"."
   (interactive (list (docker-compose-build-arguments)))
   (docker-compose--run-async "build" args))
 
 ;;;###autoload
 (defun docker-compose-create-all (args)
-  "Run \"docker-compose create\" using ARGS."
+  "Run \"docker-compose create ARGS\"."
   (interactive (list (docker-compose-create-arguments)))
   (docker-compose--run-async "create" args))
 
 ;;;###autoload
 (defun docker-compose-logs-all (args)
-  "Run \"docker-compose logs\" using ARGS."
+  "Run \"docker-compose logs ARGS\"."
   (interactive (list (docker-compose-logs-arguments)))
   (docker-compose--run-async "logs" args))
 
 ;;;###autoload
 (defun docker-compose-pull-all (args)
-  "Run \"docker-compose pull\" using ARGS."
+  "Run \"docker-compose pull ARGS\"."
   (interactive (list (docker-compose-pull-arguments)))
   (docker-compose--run "pull" args))
 
 ;;;###autoload
 (defun docker-compose-push-all (args)
-  "Run \"docker-compose push\" using ARGS."
+  "Run \"docker-compose push ARGS\"."
   (interactive (list (docker-compose-push-arguments)))
   (docker-compose--run "push" args))
 
 ;;;###autoload
 (defun docker-compose-restart-all (args)
-  "Run \"docker-compose restart\" using ARGS."
+  "Run \"docker-compose restart ARGS\"."
   (interactive (list (docker-compose-restart-arguments)))
   (docker-compose--run "restart" args))
 
 ;;;###autoload
 (defun docker-compose-rm-all (args)
-  "Run \"docker-compose rm\" using ARGS."
+  "Run \"docker-compose rm ARGS\"."
   (interactive (list (docker-compose-rm-arguments)))
   (docker-compose--run "rm" args))
 
 ;;;###autoload
 (defun docker-compose-start-all (args)
-  "Run \"docker-compose start\" using ARGS."
+  "Run \"docker-compose start ARGS\"."
   (interactive (list (docker-compose-start-arguments)))
   (docker-compose--run "start" args))
 
 ;;;###autoload
 (defun docker-compose-stop-all (args)
-  "Run \"docker-compose stop\" using ARGS."
+  "Run \"docker-compose stop ARGS\"."
   (interactive (list (docker-compose-stop-arguments)))
   (docker-compose--run "stop" args))
 
 ;;;###autoload
 (defun docker-compose-up-all (args)
-  "Run \"docker-compose up\" using ARGS."
+  "Run \"docker-compose up ARGS\"."
   (interactive (list (docker-compose-up-arguments)))
   (docker-compose--run-async "up" args))
 


### PR DESCRIPTION
I don't want the command `docker-compose config --services` run every time so I want the `all` action and the service selection action separate.
Seems create was missing so added.