### PR TITLE
Compatible with podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can also customize these using <kbd>M-x customize-variable</kbd>.
 
 | Variable                          | Description                           | Default          |
 |-----------------------------------|---------------------------------------|------------------|
-| docker-command                    | The docker binary to use              | `docker`         |
+| docker-command                    | The docker binary to use. Podman is also supported | `docker`         |
 | docker-container-default-sort-key | Sort key for docker containers        | `("Image")`      |
 | docker-container-shell-file-name  | Shell to use when entering containers | `/bin/bash`      |
 | docker-image-default-sort-key     | Sort key for docker images            | `("Repository")` |

--- a/docker-container.el
+++ b/docker-container.el
@@ -77,8 +77,8 @@ and FLIP is a boolean to specify the sort order."
 
 (defun docker-container-entries ()
   "Return the docker containers data for `tabulated-list-entries'."
-  (let* ((fmt "[{{json .ID}},{{json .Image}},{{json .Command}},{{json .CreatedAt}},{{json .Status}},{{json .Ports}},{{json .Names}}]")
-         (data (docker-run "container ls" docker-container-ls-arguments (format "--format=\"%s\"" fmt)))
+  (let* ((fmt (if(docker-utils-podman-p) "json" "[{{json .ID}},{{json .Image}},{{json .Command}},{{json .CreatedAt}},{{json .Status}},{{json .Ports}},{{json .Names}}]"))
+         (data (docker-run "container ls" docker-container-ls-arguments (format "--format=\"%s\"" fmt)
          (lines (s-split "\n" data t)))
     (-map #'docker-container-parse lines)))
 

--- a/docker-image.el
+++ b/docker-image.el
@@ -69,7 +69,7 @@ and FLIP is a boolean to specify the sort order."
 
 (defun docker-image-entries ()
   "Return the docker images data for `tabulated-list-entries'."
-  (let* ((fmt "[{{json .Repository}},{{json .Tag}},{{json .ID}},{{json .CreatedAt}},{{json .Size}}]")
+  (let* ((fmt (if (docker-utils-podman-p) "json" "[{{json .Repository}},{{json .Tag}},{{json .ID}},{{json .CreatedAt}},{{json .Size}}]"))
          (data (docker-run "image ls" docker-image-ls-arguments (format "--format=\"%s\"" fmt)))
          (lines (s-split "\n" data t)))
     (-map #'docker-image-parse lines)))

--- a/docker-network.el
+++ b/docker-network.el
@@ -60,7 +60,7 @@ and FLIP is a boolean to specify the sort order."
 
 (defun docker-network-entries ()
   "Return the docker networks data for `tabulated-list-entries'."
-  (let* ((fmt "[{{json .ID}},{{json .Name}},{{json .Driver}},{{json .Scope}}]")
+  (let* ((fmt (if (docker-utils-podman-p) "[{{json .ID}},{{json .Name}},{{json .Driver}},{{json .Scope}}]"))
          (data (docker-run "network ls" docker-network-ls-arguments (format "--format=\"%s\"" fmt)))
          (lines (s-split "\n" data t)))
     (-map #'docker-network-parse lines)))

--- a/docker-process.el
+++ b/docker-process.el
@@ -28,7 +28,7 @@
 (require 'docker-group)
 
 (defcustom docker-command "docker"
-  "The docker binary."
+  "The docker (or podman) binary."
   :group 'docker
   :type 'string)
 

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -92,6 +92,10 @@ Execute BODY in a buffer named with the help of NAME."
          (multiplier (docker-utils-unit-multiplier (-third-item parts))))
     (* value multiplier)))
 
+(defun docker-utils-podman-p ()
+  "Evaluates if podman is used as `docker-command'"
+  (string-match-p "podman" docker-command))
+
 (provide 'docker-utils)
 
 ;;; docker-utils.el ends here

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -59,7 +59,7 @@ and FLIP is a boolean to specify the sort order."
 
 (defun docker-volume-entries ()
   "Return the docker volumes data for `tabulated-list-entries'."
-  (let* ((fmt "[{{json .Driver}},{{json .Name}}]")
+  (let* ((fmt (if (docker-utils-podman-p) "json" "[{{json .Driver}},{{json .Name}}]"))
          (data (docker-run "volume ls" docker-volume-ls-arguments (format "--format=\"%s\"" fmt)))
          (lines (s-split "\n" data t)))
     (-map #'docker-volume-parse lines)))


### PR DESCRIPTION
Hello i want to make docker.el compatible with podman. The only change that has to be made is to use a different format for the output of the commands. Podman does not use the go-templates but instead uses the "json" format option instead. So this is an easy change to also use podman instead of docker to build containers.  The rest of podman is compatible to the docker cli. 