### PR TITLE
fixes parentheses broke at #105

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -82,7 +82,7 @@ and FLIP is a boolean to specify the sort order."
 (defun docker-container-entries ()
   "Return the docker containers data for `tabulated-list-entries'."
   (let* ((fmt (if(docker-utils-podman-p) "json" "[{{json .ID}},{{json .Image}},{{json .Command}},{{json .CreatedAt}},{{json .Status}},{{json .Ports}},{{json .Names}}]"))
-         (data (docker-run "container ls" docker-container-ls-arguments (format "--format=\"%s\"" fmt)
+         (data (docker-run "container ls" docker-container-ls-arguments (format "--format=\"%s\"" fmt)))
          (lines (s-split "\n" data t)))
     (-map #'docker-container-parse lines)))
 


### PR DESCRIPTION
parenthes in function `docker-container-entries` was broken at #105 
this fixes it