### PR TITLE
Correct function name to `docker-utils-setup-popup`

### DIFF
--- a/docker-network.el
+++ b/docker-network.el
@@ -99,7 +99,7 @@ and FLIP is a boolean to specify the sort order."
   'docker-network
   :man-page "docker-network-rm"
   :actions  '((?D "Remove" docker-network-rm-selection))
-  :setup-function #'docker-utils-popup-setup)
+  :setup-function #'docker-utils-setup-popup)
 
 (magit-define-popup docker-network-help-popup
   "Help popup for docker networks."


### PR DESCRIPTION
Because it was not working for me (`D` on networks screen), I found the place where function name is mistyped.