### PR TITLE
Use completing read for selecting more than one service

### DIFF
--- a/docker-compose.el
+++ b/docker-compose.el
@@ -89,7 +89,7 @@
 
 (defun docker-compose-read-services-names ()
   "Read the services names."
-  (read-string (format "Services (%s or RET): " (s-join "," (docker-compose-services)))))
+  (completing-read-multiple "Services: " (docker-compose-services)))
 
 (defun docker-compose-read-service-name ()
   "Read one service name."


### PR DESCRIPTION
Hi! First of all, thanks for your amazing package!
I use `docker-compose-logs` quite often and lack of completion causes nothing but frustration every single time. I figured that the problem is with `completing-read` and the fact that it supports choosing only one candidate.
However, `completing-read-multiple` matches required scenario perfectly in my opinion.