### PR TITLE
Fix remote docker exec from Windows build of Emacs

### DIFF
--- a/docker-utils.el
+++ b/docker-utils.el
@@ -33,10 +33,10 @@
 (defun docker-utils-shell-command-to-string (command)
   "Execute shell command COMMAND and return its output as a string.
 Wrap the function `shell-command-to-string', ensuring variable `shell-file-name' behaves properly."
-  (let* ((shell-file-name (if (and (eq system-type 'windows-nt)
-                                   (not (file-remote-p default-directory)))
-                              "cmdproxy.exe"
-                            "/bin/sh")))
+  (let ((shell-file-name (if (and (eq system-type 'windows-nt)
+                                  (not (file-remote-p default-directory)))
+                             "cmdproxy.exe"
+                           "/bin/sh")))
     (shell-command-to-string command)))
 
 (defun docker-utils-get-marked-items-ids ()

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -33,7 +33,10 @@
 (defun docker-utils-shell-command-to-string (command)
   "Execute shell command COMMAND and return its output as a string.
 Wrap the function `shell-command-to-string', ensuring variable `shell-file-name' behaves properly."
-  (let ((shell-file-name (if (eq system-type 'windows-nt) "cmdproxy.exe" "/bin/sh")))
+  (let* ((shell-file-name (if (and (eq system-type 'windows-nt)
+                                   (not (file-remote-p default-directory)))
+                              "cmdproxy.exe"
+                            "/bin/sh")))
     (shell-command-to-string command)))
 
 (defun docker-utils-get-marked-items-ids ()


### PR DESCRIPTION
When runing the windows build of Emacs, but accessing a remote server hosting docker, commands would fail as `docker-utils-shell-command-to-string` would default to `cmdproxy.exe`.

This small fix addresses the issue.