### PR TITLE
Missing --mount option

### DIFF
--- a/docker-image.el
+++ b/docker-image.el
@@ -156,6 +156,7 @@ and FLIP is a boolean to specify the sort order."
   :man-page "docker-image-run"
   :value '("-i" "-t" "--rm")
   ["Arguments"
+   ("--mount" "Mount Volume" "--mount=" read-string)
    ("-D" "With display" "-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY")
    ("-N" "Network" "--network " read-string)
    ("-P" "Privileged" "--privileged")


### PR DESCRIPTION
Added --mount option, which I gather will eventually replace the -v option.

( The pull request seems to include the previous pull request, but I'm not sure why.)