### PR TITLE
[DONT MERGE] Fix cyclic dependency

### DIFF
--- a/docker-core.el
+++ b/docker-core.el
@@ -61,17 +61,6 @@
    ("C" "Compose"    docker-compose)
    ("M" "Machines"   docker-machines)])
 
-(defun docker-arguments ()
-  "Return the latest used arguments in the `docker' transient."
-  (car (alist-get 'docker transient-history)))
-
-(defun docker-run-docker (action &rest args)
-  "Execute \"`docker-command' ACTION ARGS\"."
-  (docker-utils-with-sudo
-    (let* ((command (s-join " " (-remove 's-blank? (-flatten (list docker-command (docker-arguments) action args))))))
-      (message command)
-      (docker-utils-shell-command-to-string command))))
-
 (provide 'docker-core)
 
 ;;; docker-core.el ends here


### PR DESCRIPTION
I'm using the Emacs `native-comp` branch and there I found a bug when compiling `docker.el`.

When compiling functions in `docker-core` I would need a require to `docker-utils` as the `docker-utils-with-sudo` command is there, but `docker-utils` depends itself on `docker-core`.

This patch is just a quick fix and I moved the functions from docker-core to docker-utils.
Everything works fine for me, but now wrongly namespaced functions are in `docker-utils` (`docker-arguments` and `docker-run-docker`).
I'm short on time so I didn't really come up with a better plan to resolve the issue properly.
I'm all ears for a correct refactoring idea or other solutions.

Thanks.