### PR TITLE
transient keys need not match switch names

### DIFF
--- a/docker-compose.el
+++ b/docker-compose.el
@@ -136,13 +136,13 @@
   "Transient for \"docker-compose build\"."
   :man-page "docker-compose build"
   ["Arguments"
-   ("-b" "Build argument" "--build-arg " read-string)
-   ("-c" "Compress build context" "--compress")
-   ("-f" "Always remove intermediate containers" "--force-rm")
-   ("-m" "Memory limit" "--memory " transient-read-number-N0)
-   ("-n" "Do not use cache" "--no-cache")
-   ("-p" "Attempt to pull a newer version of the image" "--pull")
-   ("-r" "Build images in parallel" "--parallel")]
+   ("b" "Build argument" "--build-arg " read-string)
+   ("c" "Compress build context" "--compress")
+   ("f" "Always remove intermediate containers" "--force-rm")
+   ("m" "Memory limit" "--memory " transient-read-number-N0)
+   ("n" "Do not use cache" "--no-cache")
+   ("p" "Attempt to pull a newer version of the image" "--pull")
+   ("r" "Build images in parallel" "--parallel")]
   ["Actions"
    ("B" "Build" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -151,9 +151,10 @@
   "Transient for \"docker-compose config\"."
   :man-page "docker-compose config"
   ["Arguments"
-   ("-r" "Pin image tags to digests" "--resolve-image-digests")
-   ("-s" "Print the service names" "--services")
-   ("-v" "Print the volume names" "--volumes")]
+
+   ("r" "Pin image tags to digests" "--resolve-image-digests")
+   ("s" "Print the service names" "--services")
+   ("v" "Print the volume names" "--volumes")]
   ["Actions"
    ("V" "Config" docker-compose-run-action-for-all-services)])
 
@@ -161,9 +162,9 @@
   "Transient for \"docker-compose create\"."
   :man-page "docker-compose create"
   ["Arguments"
-   ("-b" "Build" "--build")
-   ("-f" "Force recreate" "--force-recreate")
-   ("-n" "No recreate" "--no-recreate")]
+   ("b" "Build" "--build")
+   ("f" "Force recreate" "--force-recreate")
+   ("n" "No recreate" "--no-recreate")]
   ["Actions"
    ("C" "Create" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -172,9 +173,9 @@
   "Transient for \"docker-compose down\"."
   :man-page "docker-compose down"
   ["Arguments"
-   ("-o" "Remove orphans" "--remove-orphans")
-   ("-t" "Timeout" "--timeout " transient-read-number-N0)
-   ("-v" "Remove volumes" "--volumes")]
+   ("o" "Remove orphans" "--remove-orphans")
+   ("t" "Timeout" "--timeout " transient-read-number-N0)
+   ("v" "Remove volumes" "--volumes")]
   ["Actions"
    ("W" "Down" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -183,12 +184,12 @@
   "Transient for \"docker-compose exec\"."
   :man-page "docker-compose exec"
   ["Arguments"
-   ("-P" "Privileged" "--privileged")
-   ("-T" "Disable pseudo-tty" "-T")
-   ("-d" "Detach" "-d")
-   ("-e" "Env KEY=VAL" "-e " read-string)
-   ("-u" "User " "--user " read-string)
-   ("-w" "Workdir" "--workdir " read-string)]
+   ("P" "Privileged" "--privileged")
+   ("T" "Disable pseudo-tty" "-T")
+   ("d" "Detach" "-d")
+   ("e" "Env KEY=VAL" "-e " read-string)
+   ("u" "User " "--user " read-string)
+   ("w" "Workdir" "--workdir " read-string)]
   ["Actions"
    ("E" "Exec" docker-compose-run-action-with-command)])
 
@@ -196,11 +197,12 @@
   "Transient for \"docker-compose logs\"."
   :man-page "docker-compose logs"
   ["Arguments"
-   ("-T" "Tail" "--tail=" read-string)
-   ("-f" "Follow" "--follow")
-   ("-n" "No color" "--no-color")
-   ("-t" "Timestamps" "--timestamps")]
+   ("T" "Tail" "--tail=" read-string)
+   ("f" "Follow" "--follow")
+   ("n" "No color" "--no-color")
+   ("t" "Timestamps" "--timestamps")]
   ["Actions"
+
    ("L" "Logs" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
 
@@ -208,9 +210,9 @@
   "Transient for \"docker-compose pull\"."
   :man-page "docker-compose pull"
   ["Arguments"
-   ("-d" "Include dependencies" "--include-deps")
-   ("-i" "Ignore pull failures" "--ignore-pull-failures")
-   ("-n" "No parallel" "--no-parallel")]
+   ("d" "Include dependencies" "--include-deps")
+   ("i" "Ignore pull failures" "--ignore-pull-failures")
+   ("n" "No parallel" "--no-parallel")]
   ["Actions"
    ("F" "Pull" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -219,7 +221,7 @@
   "Transient for \"docker-compose push\"."
   :man-page "docker-compose push"
   ["Arguments"
-   ("-i" "Ignore push failures" "--ignore-push-failures")]
+   ("i" "Ignore push failures" "--ignore-push-failures")]
   ["Actions"
    ("P" "Push" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -228,7 +230,7 @@
   "Transient for \"docker-compose restart\"."
   :man-page "docker-compose restart"
   ["Arguments"
-   ("-t" "Timeout" "--timeout " transient-read-number-N0)]
+   ("t" "Timeout" "--timeout " transient-read-number-N0)]
   ["Actions"
    ("T" "Restart" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -237,9 +239,9 @@
   "Transient for \"docker-compose rm\"."
   :man-page "docker-compose rm"
   ["Arguments"
-   ("-f" "Force" "--force")
-   ("-s" "Stop" "--stop")
-   ("-v" "Remove anonymous volumes" "-v")]
+   ("f" "Force" "--force")
+   ("s" "Stop" "--stop")
+   ("v" "Remove anonymous volumes" "-v")]
   ["Actions"
    ("D" "Remove" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -249,17 +251,17 @@
   :man-page "docker-compose run"
   :value '("--rm")
   ["Arguments"
-   ("-E" "Entrypoint" "--entrypoint " read-string)
-   ("-N" "Name" "--name " read-string)
-   ("-T" "Disable pseudo-tty" "-T")
-   ("-d" "Detach" "-d")
-   ("-e" "Env KEY=VAL" "-e " read-string)
-   ("-l" "Label" "--label " read-string)
-   ("-n" "No deps" "--no-deps")
-   ("-r" "Remove container when it exits" "--rm")
-   ("-s" "Enable services ports" "--service-ports")
-   ("-u" "User " "--user " read-string)
-   ("-w" "Workdir" "--workdir " read-string)]
+   ("E" "Entrypoint" "--entrypoint " read-string)
+   ("N" "Name" "--name " read-string)
+   ("T" "Disable pseudo-tty" "-T")
+   ("d" "Detach" "-d")
+   ("e" "Env KEY=VAL" "-e " read-string)
+   ("l" "Label" "--label " read-string)
+   ("n" "No deps" "--no-deps")
+   ("r" "Remove container when it exits" "--rm")
+   ("s" "Enable services ports" "--service-ports")
+   ("u" "User " "--user " read-string)
+   ("w" "Workdir" "--workdir " read-string)]
   ["Actions"
    ("R" "Run" docker-compose-run-action-with-command)])
 
@@ -274,7 +276,7 @@
   "Transient for \"docker-compose stop\"."
   :man-page "docker-compose stop"
   ["Arguments"
-   ("-t" "Timeout" "--timeout " transient-read-number-N0)]
+   ("t" "Timeout" "--timeout " transient-read-number-N0)]
   ["Actions"
    ("O" "Stop" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -283,13 +285,13 @@
   "Transient for \"docker-compose up\"."
   :man-page "docker-compose up"
   ["Arguments"
-   ("-b" "Build" "--build")
-   ("-c" "Scale" "--scale " transient-read-number-N0)
-   ("-d" "Detach" "-d")
-   ("-f" "Force recreate" "--force-recreate")
-   ("-n" "No deps" "--no-deps")
-   ("-r" "Remove orphans" "--remove-orphans")
-   ("-t" "Timeout" "--timeout " transient-read-number-N0)]
+   ("b" "Build" "--build")
+   ("c" "Scale" "--scale " transient-read-number-N0)
+   ("d" "Detach" "-d")
+   ("f" "Force recreate" "--force-recreate")
+   ("n" "No deps" "--no-deps")
+   ("r" "Remove orphans" "--remove-orphans")
+   ("t" "Timeout" "--timeout " transient-read-number-N0)]
   ["Actions"
    ("U" "Up" docker-compose-run-action-for-one-service)
    ("A" "All services" docker-compose-run-action-for-all-services)])
@@ -303,14 +305,14 @@
   "Transient for docker-compose."
   :man-page "docker-compose"
   ["Arguments"
-   ("-a" "No ANSI" "--no-ansi")
-   ("-c" "Compatibility" "--compatibility")
-   ("-d" "Project directory" "--project-directory " docker-compose-read-directory)
-   ("-f" "Compose file" "--file " docker-compose-read-compose-file)
-   ("-h" "Host" "--host " read-string)
-   ("-l" "Log level" "--log-level " docker-compose-read-log-level)
-   ("-p" "Project name" "--project-name " read-string)
-   ("-v" "Verbose" "--verbose")]
+   ("a" "No ANSI" "--no-ansi")
+   ("c" "Compatibility" "--compatibility")
+   ("d" "Project directory" "--project-directory " docker-compose-read-directory)
+   ("f" "Compose file" "--file " docker-compose-read-compose-file)
+   ("h" "Host" "--host " read-string)
+   ("l" "Log level" "--log-level " docker-compose-read-log-level)
+   ("p" "Project name" "--project-name " read-string)
+   ("v" "Verbose" "--verbose")]
   [["Images"
     ("B" "Build"      docker-compose-build)
     ("F" "Pull"       docker-compose-pull)

--- a/docker-container.el
+++ b/docker-container.el
@@ -217,8 +217,8 @@ and FLIP is a boolean to specify the sort order."
   "Transient for attaching to containers."
   :man-page "docker-container-attach"
   ["Arguments"
-   ("-n" "No STDIN" "--no-stdin")
-   ("-d" "Key sequence for detaching" "--detach-keys=" read-string)]
+   ("n" "No STDIN" "--no-stdin")
+   ("d" "Key sequence for detaching" "--detach-keys=" read-string)]
   [:description docker-utils-generic-actions-heading
    ("a" "Attach" docker-utils-generic-action-async)])
 
@@ -251,7 +251,7 @@ and FLIP is a boolean to specify the sort order."
   "Transient for kill signaling containers"
   :man-page "docker-container-kill"
   ["Arguments"
-   ("-s" "Signal" "-s " read-string)]
+   ("s" "Signal" "-s " read-string)]
   [:description docker-utils-generic-actions-heading
    ("K" "Kill" docker-utils-generic-action)])
 
@@ -259,10 +259,10 @@ and FLIP is a boolean to specify the sort order."
   "Transient for showing containers logs."
   :man-page "docker-container-logs"
   ["Arguments"
-   ("-f" "Follow" "-f")
-   ("-s" "Since" "--since " read-string)
-   ("-t" "Tail" "--tail " read-string)
-   ("-u" "Until" "--until " read-string)]
+   ("f" "Follow" "-f")
+   ("s" "Since" "--since " read-string)
+   ("t" "Tail" "--tail " read-string)
+   ("u" "Until" "--until " read-string)]
   [:description docker-utils-generic-actions-heading
    ("L" "Logs" docker-utils-generic-action-async)])
 
@@ -275,11 +275,11 @@ and FLIP is a boolean to specify the sort order."
   :man-page "docker-container-ls"
   :value '("--all")
   ["Arguments"
-   ("-N" "Last" "--last " transient-read-number-N0)
-   ("-a" "All" "--all")
-   ("-e" "Exited containers" "--filter status=exited")
-   ("-f" "Filter" "--filter " read-string)
-   ("-n" "Don't truncate" "--no-trunc")]
+   ("N" "Last" "--last " transient-read-number-N0)
+   ("a" "All" "--all")
+   ("e" "Exited containers" "--filter status=exited")
+   ("f" "Filter" "--filter " read-string)
+   ("n" "Don't truncate" "--no-trunc")]
   ["Actions"
    ("l" "List" tablist-revert)])
 
@@ -294,7 +294,7 @@ and FLIP is a boolean to specify the sort order."
   "Transient for restarting containers."
   :man-page "docker-container-restart"
   ["Arguments"
-   ("-t" "Timeout" "-t " transient-read-number-N0)]
+   ("t" "Timeout" "-t " transient-read-number-N0)]
   [:description docker-utils-generic-actions-heading
    ("R" "Restart" docker-utils-generic-action)])
 
@@ -302,8 +302,8 @@ and FLIP is a boolean to specify the sort order."
   "Transient for removing containers."
   :man-page "docker-container-rm"
   ["Arguments"
-   ("-f" "Force" "-f")
-   ("-v" "Volumes" "-v")]
+   ("f" "Force" "-f")
+   ("v" "Volumes" "-v")]
   [:description docker-utils-generic-actions-heading
    ("D" "Remove" docker-utils-generic-action)])
 
@@ -323,7 +323,7 @@ and FLIP is a boolean to specify the sort order."
   "Transient for stoping containers."
   :man-page "docker-container-stop"
   ["Arguments"
-   ("-t" "Timeout" "-t " transient-read-number-N0)]
+   ("t" "Timeout" "-t " transient-read-number-N0)]
   [:description docker-utils-generic-actions-heading
    ("O" "Stop" docker-utils-generic-action)])
 

--- a/docker-image.el
+++ b/docker-image.el
@@ -118,10 +118,10 @@ and FLIP is a boolean to specify the sort order."
   "Transient for listing images."
   :man-page "docker-image-ls"
   ["Arguments"
-   ("-a" "All" "--all")
-   ("-d" "Dangling" "-f dangling=true")
-   ("-f" "Filter" "--filter" read-string)
-   ("-n" "Don't truncate" "--no-trunc")]
+   ("a" "All" "--all")
+   ("d" "Dangling" "-f dangling=true")
+   ("f" "Filter" "--filter" read-string)
+   ("n" "Don't truncate" "--no-trunc")]
   ["Actions"
    ("l" "List" tablist-revert)])
 
@@ -129,7 +129,7 @@ and FLIP is a boolean to specify the sort order."
   "Transient for pulling images."
   :man-page "docker-image-pull"
   ["Arguments"
-   ("-a" "All" "-a")]
+   ("a" "All" "-a")]
   [:description docker-utils-generic-actions-heading
    ("F" "Pull selection" docker-utils-generic-action)
    ("N" "Pull a new image" docker-image-pull-one)])
@@ -154,24 +154,24 @@ and FLIP is a boolean to specify the sort order."
   :man-page "docker-image-run"
   :value '("-i" "-t" "--rm")
   ["Arguments"
-   ("-D" "With display" "-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY")
-   ("-M" "Mount volume" "--mount=" read-string)
-   ("-N" "Network" "--network " read-string)
-   ("-P" "Privileged" "--privileged")
-   ("-T" "Synchronize time" "-v /etc/localtime:/etc/localtime:ro")
-   ("-W" "Web ports" "-p 80:80 -p 443:443 -p 8080:8080")
-   ("-d" "Detach" "-d")
-   ("-e" "environment" "-e " read-string)
-   ("-i" "Interactive" "-i")
-   ("-m" "name" "--name " read-string)
-   ("-n" "entrypoint" "--entrypoint " read-string)
-   ("-o" "Read only" "--read-only")
-   ("-p" "port" "-p " read-string)
-   ("-r" "Remove container when it exits" "--rm")
-   ("-t" "TTY" "-t")
-   ("-u" "user" "-u " read-string)
-   ("-v" "volume" "-v " read-string)
-   ("-w" "workdir" "-w " read-string)]
+   ("D" "With display" "-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY")
+   ("M" "Mount volume" "--mount=" read-string)
+   ("N" "Network" "--network " read-string)
+   ("P" "Privileged" "--privileged")
+   ("T" "Synchronize time" "-v /etc/localtime:/etc/localtime:ro")
+   ("W" "Web ports" "-p 80:80 -p 443:443 -p 8080:8080")
+   ("d" "Detach" "-d")
+   ("e" "environment" "-e " read-string)
+   ("i" "Interactive" "-i")
+   ("m" "name" "--name " read-string)
+   ("n" "entrypoint" "--entrypoint " read-string)
+   ("o" "Read only" "--read-only")
+   ("p" "port" "-p " read-string)
+   ("r" "Remove container when it exits" "--rm")
+   ("t" "TTY" "-t")
+   ("u" "user" "-u " read-string)
+   ("v" "volume" "-v " read-string)
+   ("w" "workdir" "-w " read-string)]
   [:description docker-utils-generic-actions-heading
    ("R" "Run" docker-image-run-selection)])
 

--- a/docker-machine.el
+++ b/docker-machine.el
@@ -154,8 +154,8 @@ and FLIP is a boolean to specify the sort order."
   "Transient for listing machines."
   :man-page "docker-machine-ls"
   ["Arguments"
-   ("-f" "Filter" "--filter " read-string)
-   ("-t" "Timeout" "--timeout " transient-read-number-N0)]
+   ("f" "Filter" "--filter " read-string)
+   ("t" "Timeout" "--timeout " transient-read-number-N0)]
   ["Actions"
    ("l" "List" tablist-revert)])
 
@@ -170,8 +170,8 @@ and FLIP is a boolean to specify the sort order."
   :man-page "docker-machine-rm"
   :value '("-y")
   ["Arguments"
-   ("-f" "Force" "-f")
-   ("-y" "Automatic yes" "-y")]
+   ("f" "Force" "-f")
+   ("y" "Automatic yes" "-y")]
   [:description docker-utils-generic-actions-heading
    ("D" "Remove" docker-machine-generic-action)])
 

--- a/docker-network.el
+++ b/docker-network.el
@@ -80,8 +80,8 @@ and FLIP is a boolean to specify the sort order."
   "Transient for listing networks."
   :man-page "docker-network-ls"
   ["Arguments"
-   ("-f" "Filter" "--filter " read-string)
-   ("-n" "Don't truncate" "--no-trunc")]
+   ("f" "Filter" "--filter " read-string)
+   ("n" "Don't truncate" "--no-trunc")]
   ["Actions"
    ("l" "List" tablist-revert)])
 

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -93,7 +93,7 @@ and FLIP is a boolean to specify the sort order."
   "Transient for listing volumes."
   :man-page "docker-volume-ls"
   ["Arguments"
-   ("-f" "Filter" "--filter " read-string)]
+   ("f" "Filter" "--filter " read-string)]
   ["Actions"
    ("l" "List" tablist-revert)])
 

--- a/docker.el
+++ b/docker.el
@@ -49,13 +49,13 @@
   "Transient for docker."
   :man-page "docker"
   ["Arguments"
-   (5 "-H" "Host" "--host " read-string)
-   (5 "-Tt" "TLS" "--tls")
-   (5 "-Tv" "TLS verify remote" "--tlsverify")
-   (5 "-Ta" "TLS CA" "--tlscacert" docker-read-certificate)
-   (5 "-Tc" "TLS certificate" "--tlscert" docker-read-certificate)
-   (5 "-Tk" "TLS key" "--tlskey" docker-read-certificate)
-   (5 "-l" "Log level" "--log-level " docker-read-log-level)]
+   (5 "H" "Host" "--host " read-string)
+   (5 "Tt" "TLS" "--tls")
+   (5 "Tv" "TLS verify remote" "--tlsverify")
+   (5 "Ta" "TLS CA" "--tlscacert" docker-read-certificate)
+   (5 "Tc" "TLS certificate" "--tlscert" docker-read-certificate)
+   (5 "Tk" "TLS key" "--tlskey" docker-read-certificate)
+   (5 "l" "Log level" "--log-level " docker-read-log-level)]
   ["Docker"
    ("c" "Containers" docker-containers)
    ("i" "Images"     docker-images)


### PR DESCRIPTION
Hey there,

I don't think the leading dash adds any value here.  It's just more typing.  Also, it's misleading for cases where the "switch" doesn't exist in the underlying docker command like -M for --mount.

Regards,
-Doug
