### PR TITLE
Choose initial docker run infix args Based on Repository Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,29 @@ https://magit.vc/manual/transient/Enabling-and-Disabling-Suffixes.html for more 
 
 Here is a list of other customizations you can set:
 
-| Variable                          | Description                           | Default          |
-|-----------------------------------|---------------------------------------|------------------|
-| docker-command                    | The docker binary to use              | `docker`         |
-| docker-container-default-sort-key | Sort key for docker containers        | `("Image")`      |
-| docker-container-shell-file-name  | Shell to use when entering containers | `/bin/sh`        |
-| docker-image-default-sort-key     | Sort key for docker images            | `("Repository")` |
-| docker-machine-default-sort-key   | Sort key for docker machines          | `("Name")`       |
-| docker-network-default-sort-key   | Sort key for docker networks          | `("Name")`       |
-| docker-run-as-root                | Run docker as root                    | `nil`            |
-| docker-volume-default-sort-key    | Sort key for docker volumes           | `("Driver")`     |
+| Variable                          | Description                           | Default              |
+|-----------------------------------|---------------------------------------|----------------------|
+| docker-command                    | The docker binary to use              | `docker`             |
+| docker-container-default-sort-key | Sort key for docker containers        | `("Image")`          |
+| docker-container-shell-file-name  | Shell to use when entering containers | `/bin/sh`            |
+| docker-image-default-sort-key     | Sort key for docker images            | `("Repository")`     |
+| docker-machine-default-sort-key   | Sort key for docker machines          | `("Name")`           |
+| docker-network-default-sort-key   | Sort key for docker networks          | `("Name")`           |
+| docker-run-as-root                | Run docker as root                    | `nil`                |
+| docker-volume-default-sort-key    | Sort key for docker volumes           | `("Driver")`         |
+| docker-run-default-args           | Base arguments to use for docker run  | `("-i" "-t" "--rm")` |
+
+### Changing the Default Arguments for `docker run`
+
+You can match on the repository name for an image to customize the initial infix arguments via `docker-image-run-custom-args`:
+
+```elips
+(add-to-list
+   'docker-image-run-custom-args
+   `("^postgres" ("-e POSTGRES_PASSWORD=postgres" . ,docker-run-default-args)))
+```
+
+So when `docker run` is called on an image whose repository name matches the regular expression `^postgres`, the option `"-e POSTGRES_PASSWORD=postgres"` will appear as set along with the defaults specified by `docker-run-default-args`.
 
 ## FAQ
 

--- a/docker-image.el
+++ b/docker-image.el
@@ -53,18 +53,23 @@ and FLIP is a boolean to specify the sort order."
 
 (defcustom docker-run-default-args
   '("-i" "-t" "--rm")
-  "Default infix args used when docker run is invoked."
+  "Default infix args used when docker run is invoked.
+
+Note this can be overriden for specific images using
+`docker-image-run-custom-args'."
   :group 'docker-run
   :type '(repeat string))
 
-(defvar docker-run-arg-init-list nil)
+(defcustom docker-image-run-custom-args
+  nil
+  "List which can be used to customize the default arguments for docker run.
 
-(defun docker-register-run-args-for-regex (regex args)
-  "Register infix arguments for matching docker images.
+Its elements should be of the form (REGEX ARGS) where
+REGEX is a (string) regular expression and ARGS is a list of strings
+corresponding to arguments.
 
-Register infix arguments ARGS for docker run when the
-image repository string matches the string REGEX."
-  (add-to-list 'docker-run-arg-init-list `(,regex ,args)))
+Also note if you do not specify `docker-run-default-args', they will be ignored."
+  :type '(repeat (list string (repeat string))))
 
 (defun docker-image-parse (line)
   "Convert a LINE from \"docker image ls\" to a `tabulated-list-entries' entry."
@@ -172,7 +177,7 @@ image repository string matches the string REGEX."
                   (_ (not (cdr images)))
                   (repo-name (caar images))
                   (matched-args (--first (string-match (car it) repo-name)
-                                         docker-run-arg-init-list)))
+                                         docker-image-run-custom-args)))
             (cadr matched-args)
           docker-run-default-args)))
 

--- a/docker-image.el
+++ b/docker-image.el
@@ -51,6 +51,21 @@ and FLIP is a boolean to specify the sort order."
                (choice (const :tag "Ascending" nil)
                        (const :tag "Descending" t))))
 
+(defcustom docker-run-default-args
+  '("-i" "-t" "--rm")
+  "Default infix args used when docker run is invoked."
+  :group 'docker-run
+  :type '(repeat string))
+
+(defvar docker-run-arg-init-list nil)
+
+(defun docker-register-run-args-for-regex (regex args)
+  "Register infix arguments for matching docker images.
+
+Register infix arguments ARGS for docker run when the
+image repository string matches the string REGEX."
+  (add-to-list 'docker-run-arg-init-list `(,regex ,args)))
+
 (defun docker-image-parse (line)
   "Convert a LINE from \"docker image ls\" to a `tabulated-list-entries' entry."
   (condition-case nil
@@ -149,10 +164,22 @@ and FLIP is a boolean to specify the sort order."
   [:description docker-utils-generic-actions-heading
    ("D" "Remove" docker-utils-generic-action)])
 
+(defclass docker-run-prefix (transient-prefix) nil)
+
+(cl-defmethod transient-init-value ((obj docker-run-prefix))
+  (oset obj value
+        (if-let* ((images (tablist-get-marked-items))
+                  (_ (not (cdr images)))
+                  (repo-name (caar images))
+                  (matched-args (--first (string-match (car it) repo-name)
+                                         docker-run-arg-init-list)))
+            (cadr matched-args)
+          docker-run-default-args)))
+
 (docker-utils-transient-define-prefix docker-image-run ()
   "Transient for running images."
   :man-page "docker-image-run"
-  :value '("-i" "-t" "--rm")
+  :class 'docker-run-prefix
   ["Arguments"
    ("D" "With display" "-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY")
    ("M" "Mount volume" "--mount=" read-string)


### PR DESCRIPTION
Hi! This PR adds the option for users to populate infix args for `docker run` based on the repository string of the image, for example, with this snippet:

```elisp
(docker-register-run-args-for-regex
   "^postgres"
   `("-e POSTGRES_PASSWORD=postgres" . ,docker-run-default-args))
```

You would get the following when attempting to run a postgres image:

<img width="871" alt="docker-example" src="https://user-images.githubusercontent.com/17688577/112837757-2e395180-9094-11eb-84d1-90ca2c20b667.png">

I'm no expert on transient, so if this is already possible in some way or you have any issues, let me know :slightly_smiling_face: 

Thanks!