### PR TITLE
Refresh Docker Images after Pulling

### DIFF
--- a/docker-image.el
+++ b/docker-image.el
@@ -106,7 +106,8 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
 (defun docker-image-pull-one (name &optional all)
   "Pull the image named NAME.  If ALL is set, use \"-a\"."
   (interactive (list (docker-image-read-name) current-prefix-arg))
-  (docker-run-docker "pull" (when all "-a ") name))
+  (docker-run-docker "pull" (when all "-a ") name)
+  (tablist-revert))
 
 (defun docker-image-run-selection (command)
   "Run \"docker image run\" with COMMAND on the images selection."


### PR DESCRIPTION
Hi!

This is a really small PR which just refreshes the tablist after a `docker-image-pull-one` so that the newly pulled image appears in the list:

Before:

https://user-images.githubusercontent.com/17688577/129918715-cf1140e6-9d00-4367-bf89-17b14232faa6.mp4

After:

https://user-images.githubusercontent.com/17688577/129918600-db43116c-a390-4203-bd48-7b789b228254.mp4

Feel free to shoot me down if there's a good reason you're not doing this already, thanks!
