### PR TITLE
Add inspect function to all modes which use tablist

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -270,12 +270,6 @@ nil, ask the user for it."
    ("d" "Open directory" docker-container-find-directory-selection)
    ("f" "Open file" docker-container-find-file-selection)])
 
-(docker-utils-transient-define-prefix docker-container-inspect ()
-  "Transient for inspecting containers."
-  :man-page "docker-container-inspect"
-  [:description docker-utils-generic-actions-heading
-   ("I" "Inspect" docker-utils-generic-action-with-buffer:json)])
-
 (docker-utils-transient-define-prefix docker-container-kill ()
   "Transient for kill signaling containers"
   :man-page "docker-container-kill"
@@ -362,7 +356,7 @@ nil, ask the user for it."
   ["Docker containers help"
    ("C" "Copy"       docker-container-cp)
    ("D" "Remove"     docker-container-rm)
-   ("I" "Inspect"    docker-container-inspect)
+   ("I" "Inspect"    docker-utils-inspect)
    ("K" "Kill"       docker-container-kill)
    ("L" "Logs"       docker-container-logs)
    ("O" "Stop"       docker-container-stop)
@@ -381,7 +375,7 @@ nil, ask the user for it."
     (define-key map "?" 'docker-container-help)
     (define-key map "C" 'docker-container-cp)
     (define-key map "D" 'docker-container-rm)
-    (define-key map "I" 'docker-container-inspect)
+    (define-key map "I" 'docker-utils-inspect)
     (define-key map "K" 'docker-container-kill)
     (define-key map "L" 'docker-container-logs)
     (define-key map "O" 'docker-container-stop)

--- a/docker-image.el
+++ b/docker-image.el
@@ -125,12 +125,6 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
     (docker-run-docker "tag" it (read-string (format "Tag for %s: " it))))
   (tablist-revert))
 
-(docker-utils-transient-define-prefix docker-image-inspect ()
-  "Transient for inspecting images."
-  :man-page "docker-image-inspect"
-  [:description docker-utils-generic-actions-heading
-   ("I" "Inspect" docker-utils-generic-action-with-buffer:json)])
-
 (defun docker-image-ls-arguments ()
   "Return the latest used arguments in the `docker-image-ls' transient."
   (car (alist-get 'docker-image-ls transient-history)))
@@ -215,7 +209,7 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
   ["Docker images help"
    ("D" "Remove"  docker-image-rm)
    ("F" "Pull"    docker-image-pull)
-   ("I" "Inspect" docker-image-inspect)
+   ("I" "Inspect" docker-utils-inspect)
    ("P" "Push"    docker-image-push)
    ("R" "Run"     docker-image-run)
    ("T" "Tag"     docker-image-tag-selection)
@@ -226,7 +220,7 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
     (define-key map "?" 'docker-image-help)
     (define-key map "D" 'docker-image-rm)
     (define-key map "F" 'docker-image-pull)
-    (define-key map "I" 'docker-image-inspect)
+    (define-key map "I" 'docker-utils-inspect)
     (define-key map "P" 'docker-image-push)
     (define-key map "R" 'docker-image-run)
     (define-key map "T" 'docker-image-tag-selection)

--- a/docker-network.el
+++ b/docker-network.el
@@ -95,6 +95,7 @@ and FLIP is a boolean to specify the sort order."
   "Help transient for docker networks."
   ["Docker networks help"
    ("D" "Remove"     docker-network-rm)
+   ("I" "Inspect"    docker-utils-inspect)
    ("l" "List"       docker-network-ls)])
 
 (defvar docker-network-mode-map
@@ -102,6 +103,7 @@ and FLIP is a boolean to specify the sort order."
     (define-key map "?" 'docker-network-help)
     (define-key map "D" 'docker-network-rm)
     (define-key map "l" 'docker-network-ls)
+    (define-key map "I" 'docker-utils-inspect)
     map)
   "Keymap for `docker-network-mode'.")
 

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -117,6 +117,15 @@ Execute BODY in a buffer named with the help of NAME."
          (multiplier (docker-utils-unit-multiplier (-third-item parts))))
     (* value multiplier)))
 
+(defun docker-utils-inspect ()
+  "Docker Inspect the tablist entry under point."
+  (interactive)
+  (let ((entry-id (tabulated-list-get-id)))
+    (docker-utils-with-buffer (format "inspect %s" entry-id)
+      (insert (docker-run-docker "inspect" () entry-id))
+      (js-mode)
+      (view-mode))))
+
 (provide 'docker-utils)
 
 ;;; docker-utils.el ends here

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -108,6 +108,7 @@ and FLIP is a boolean to specify the sort order."
   ["Docker volumes help"
    ("D" "Remove"     docker-volume-rm)
    ("d" "Dired"      docker-volume-dired-selection)
+   ("I" "Inspect"    docker-utils-inspect)
    ("l" "List"       docker-volume-ls)])
 
 (defvar docker-volume-mode-map
@@ -116,6 +117,7 @@ and FLIP is a boolean to specify the sort order."
     (define-key map "D" 'docker-volume-rm)
     (define-key map "d" 'docker-volume-dired-selection)
     (define-key map "l" 'docker-volume-ls)
+    (define-key map "I" 'docker-utils-inspect)
     map)
   "Keymap for `docker-volume-mode'.")
 


### PR DESCRIPTION
Changes:
* Adds inspect function to docker-volumes and docker-networks
* Changes function from a transient to an interactive function to avoid the empty transient menu
* Sets js-mode and view-mode in the new buffer with docker inspect output
* Changes the inspect function from docker-images and docker-containers to match

Notes
* Unlike the docker-container-inspect transient, docker-utils-inspect ignores marked values and just inspects the thing at point.
* It probably would have been better to use json-mode instead of js-mode, but I didn't want to introduce a new dependency.