### PR TITLE
Column reorder feature

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -38,9 +38,8 @@
   "Docker container customization group."
   :group 'docker)
 
-;; TODO previously from col 6 Names?
 (defconst docker-container-id-template
-  "{{ json .ID }}"
+  "{{ json .Names }}"
   "This Go template extracts the container id which will be passed to transient commands.")
 
 (defcustom docker-container-shell-file-name "/bin/sh"

--- a/docker-container.el
+++ b/docker-container.el
@@ -409,9 +409,7 @@ nil, ask the user for it."
 
 (define-derived-mode docker-container-mode tabulated-list-mode "Containers Menu"
   "Major mode for handling a list of docker containers."
-  (setq tabulated-list-format (seq-into
-                               (-map (lambda (x) (list (car x) (cdr x) t)) docker-container-column-order)
-                               'vector))
+  (setq tabulated-list-format (docker-utils-column-order-list-format docker-container-column-order))
   (setq tabulated-list-padding 2)
   (setq tabulated-list-sort-key docker-container-default-sort-key)
   (add-hook 'tabulated-list-revert-hook 'docker-container-refresh nil t)

--- a/docker-container.el
+++ b/docker-container.el
@@ -55,8 +55,11 @@ This should be a cons cell (NAME . FLIP) where
 NAME is a string matching one of the column names
 and FLIP is a boolean to specify the sort order."
   :group 'docker-container
-  ;; TODO could generate column choices from docker-image-column-order
-  :type '(cons (string :tag "Column Name")
+  :type '(cons (string :tag "Column Name"
+                       :validate (lambda (widget)
+                                   (unless (--any-p (equal (plist-get it :name) (widget-value widget)) docker-container-column-spec)
+                                     (widget-put widget :error "Default Sort Key must match a column name")
+                                     widget)))
                (choice (const :tag "Ascending" nil)
                        (const :tag "Descending" t))))
 

--- a/docker-image.el
+++ b/docker-image.el
@@ -37,8 +37,10 @@
   :group 'docker)
 
 (defconst docker-image-id-template
-  "{{ json .ID }}"
-  "This Go template extracts the image id which will be passed to transient commands.")
+  "{{if (eq \\\"<none>\\\" .Repository .Tag)}}{{ json .ID }}{{else}}\\\"{{ .Repository }}:{{ .Tag }}\\\"{{end}}"
+  "This Go template defines what will be passed to transient commands.
+
+The default value uses Repository:Tag unless either is <none>, then it uses Id.")
 
 (defcustom docker-image-default-sort-key '("Repository" . nil)
   "Sort key for docker images.
@@ -66,9 +68,7 @@ and FLIP is a boolean to specify the sort order."
 The order of entries defines the displayed column order.
 'Template' is the Go template passed to docker-image-ls to generate the column data."
   :group 'docker-image
-  ;; add plist symbols
   :set 'docker-utils-column-spec-setter
-  ;; removes plist symbols
   :get 'docker-utils-column-spec-getter
   :type '(repeat (list :tag "Column"
                        (string :tag "Name")

--- a/docker-image.el
+++ b/docker-image.el
@@ -56,9 +56,12 @@
 This should be a cons cell (NAME . FLIP) where
 NAME is a string matching one of the column names
 and FLIP is a boolean to specify the sort order."
-  :group 'docker-image)
-  ;; TODO generate column choices from docker-image-column-order
-;;  :type (docker-utils-sort-key-customize-type docker-image-default-column-order))
+  :group 'docker-image
+  ;; TODO could generate column choices from docker-image-column-order
+  :type '(cons (string :tag "Column Name")
+               (choice (const :tag "Ascending" nil)
+                       (const :tag "Descending" t))))
+
 
 (defcustom docker-image-column-order docker-image-default-columns
   "Column specification for docker images.
@@ -117,11 +120,6 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
         (list (aref data 0) (seq-drop data 1)))
     (json-readtable-error
      (error "Could not read following string as json:\n%s" line))))
-
-(defun docker-utils-make-format-string (id-template column-spec)
-  (let* ((templates (--map (plist-get it :template) column-spec))
-         (delimited (string-join templates ",")))
-    (format "[%s,%s]" id-template delimited)))
 
 (defun docker-image-entries ()
   "Return the docker images data for `tabulated-list-entries'."
@@ -277,12 +275,6 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
   (docker-utils-pop-to-buffer "*docker-images*")
   (docker-image-mode)
   (tablist-revert))
-
-(defun docker-utils-column-order-list-format (columns-spec)
-  "Convert COLUMNS-SPEC (a list of plists) to 'tabulated-list-format' (a vector of (name width bool))."
-  (seq-into
-   (--map (list (plist-get it :name) (plist-get it :width) (or (plist-get it :sort) t)) columns-spec)
-   'vector))
 
 (define-derived-mode docker-image-mode tabulated-list-mode "Images Menu"
   "Major mode for handling a list of docker images."

--- a/docker-image.el
+++ b/docker-image.el
@@ -244,11 +244,10 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
   (docker-image-mode)
   (tablist-revert))
 
+;; TODO previously Size column was sorted with docker-image-human-size-predicate
 (define-derived-mode docker-image-mode tabulated-list-mode "Images Menu"
   "Major mode for handling a list of docker images."
-  (setq tabulated-list-format (seq-into
-                               (-map (lambda (x) (list (car x) (cdr x) t)) docker-image-column-order)
-                               'vector))
+  (setq tabulated-list-format (docker-utils-column-order-list-format docker-image-column-order))
   (setq tabulated-list-padding 2)
   (setq tabulated-list-sort-key docker-image-default-sort-key)
   (add-hook 'tabulated-list-revert-hook 'docker-image-refresh nil t)

--- a/docker-image.el
+++ b/docker-image.el
@@ -40,7 +40,6 @@
   "{{ json .ID }}"
   "This Go template extracts the image id which will be passed to transient commands.")
 
-;; TODO default sort key may not exist?
 (defcustom docker-image-default-sort-key '("Repository" . nil)
   "Sort key for docker images.
 
@@ -48,11 +47,13 @@ This should be a cons cell (NAME . FLIP) where
 NAME is a string matching one of the column names
 and FLIP is a boolean to specify the sort order."
   :group 'docker-image
-  ;; TODO could generate column choices from docker-image-column-order
-  :type '(cons (string :tag "Column Name")
+  :type '(cons (string :tag "Column Name"
+                       :validate (lambda (widget)
+                                   (unless (--any-p (equal (plist-get it :name) (widget-value widget)) docker-image-column-spec)
+                                     (widget-put widget :error "Default Sort Key must match a column name")
+                                     widget)))
                (choice (const :tag "Ascending" nil)
                        (const :tag "Descending" t))))
-
 
 (defcustom docker-image-column-spec
   '((:name "Repository" :width 30 :template "{{json .Repository}}" :sort nil :format nil)

--- a/docker-image.el
+++ b/docker-image.el
@@ -244,10 +244,14 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
   (docker-image-mode)
   (tablist-revert))
 
-;; TODO previously Size column was sorted with docker-image-human-size-predicate
 (define-derived-mode docker-image-mode tabulated-list-mode "Images Menu"
   "Major mode for handling a list of docker images."
   (setq tabulated-list-format (docker-utils-column-order-list-format docker-image-column-order))
+  ;; Manually set sort function of "Size" column
+  (let* ((size-pos (seq-position tabulated-list-format "Size" (lambda (x y) (equal (car x) y))))
+         (current-elt (aref tabulated-list-format size-pos)))
+    (aset tabulated-list-format size-pos (list "Size" (elt current-elt 1) 'docker-image-human-size-predicate)))
+
   (setq tabulated-list-padding 2)
   (setq tabulated-list-sort-key docker-image-default-sort-key)
   (add-hook 'tabulated-list-revert-hook 'docker-image-refresh nil t)

--- a/docker-image.el
+++ b/docker-image.el
@@ -106,27 +106,12 @@ corresponding to arguments.
 Also note if you do not specify `docker-run-default-args', they will be ignored."
   :type '(repeat (list string (repeat string))))
 
-(defun docker-image-parse (column-specs line)
-  "Convert a LINE from \"docker image ls\" to a `tabulated-list-entries' entry."
-  (condition-case nil
-      (let* ((data (json-read-from-string line)))
-        ;; apply format function, if any
-        (--each-indexed
-            column-specs
-          (let ((fmt-fn (plist-get it :format))
-                (data-index (+ it-index 1)))
-            (when fmt-fn (aset data data-index (apply fmt-fn (list (aref data data-index)))))))
-
-        (list (aref data 0) (seq-drop data 1)))
-    (json-readtable-error
-     (error "Could not read following string as json:\n%s" line))))
-
 (defun docker-image-entries ()
   "Return the docker images data for `tabulated-list-entries'."
   (let* ((fmt (docker-utils-make-format-string docker-image-id-template docker-image-column-order))
          (data (docker-run-docker "image ls" (docker-image-ls-arguments) (format "--format=\"%s\"" fmt)))
          (lines (s-split "\n" data t)))
-    (-map (-partial #'docker-image-parse docker-image-column-order) lines)))
+    (-map (-partial #'docker-utils-parse docker-image-column-order) lines)))
 
 (defun docker-image-refresh ()
   "Refresh the images list."

--- a/docker-image.el
+++ b/docker-image.el
@@ -46,7 +46,7 @@
     (:name "Tag" :width 20 :template "{{ json .Tag }}" :sort nil :format nil)
     (:name "Id" :width 16 :template "{{ json .ID }}" :sort nil :format nil)
     (:name "Created" :width 24 :template "{{ json .CreatedAt }}" :sort nil :format (lambda (x) (format-time-string "%F %T" (date-to-time x))))
-    (:name "Size" :width 10 :template "{{ json .Size }}" :sort docker-image-human-size-predicate :format nil))
+    (:name "Size" :width 10 :template "{{ json .Size }}" :sort docker-utils-human-size-predicate :format nil))
   "Default column specs for docker-images.")
 
 ;; TODO default sort key may not exist?
@@ -120,12 +120,6 @@ Also note if you do not specify `docker-run-default-args', they will be ignored.
 (defun docker-image-read-name ()
   "Read an image name."
   (completing-read "Image: " (-map #'car (docker-image-entries))))
-
-(defun docker-image-human-size-predicate (a b)
-  "Sort A and B by image size."
-  (let* ((a-size (elt (cadr a) 4))
-         (b-size (elt (cadr b) 4)))
-    (< (docker-utils-human-size-to-bytes a-size) (docker-utils-human-size-to-bytes b-size))))
 
 ;;;###autoload
 (defun docker-image-pull-one (name &optional all)

--- a/docker-network.el
+++ b/docker-network.el
@@ -126,9 +126,7 @@ and FLIP is a boolean to specify the sort order."
 
 (define-derived-mode docker-network-mode tabulated-list-mode "Networks Menu"
   "Major mode for handling a list of docker networks."
-  (setq tabulated-list-format (seq-into
-                               (-map (lambda (x) (list (car x) (cdr x) t)) docker-network-column-order)
-                               'vector))
+  (setq tabulated-list-format (docker-utils-column-order-list-format docker-network-column-order))
   (setq tabulated-list-padding 2)
   (setq tabulated-list-sort-key docker-network-default-sort-key)
   (add-hook 'tabulated-list-revert-hook 'docker-network-refresh nil t)

--- a/docker-network.el
+++ b/docker-network.el
@@ -47,7 +47,11 @@ This should be a cons cell (NAME . FLIP) where
 NAME is a string matching one of the column names
 and FLIP is a boolean to specify the sort order."
   :group 'docker-network
-  :type '(cons (string :tag "Column Name")
+  :type '(cons (string :tag "Column Name"
+                       :validate (lambda (widget)
+                                   (unless (--any-p (equal (plist-get it :name) (widget-value widget)) docker-network-column-spec)
+                                     (widget-put widget :error "Default Sort Key must match a column name")
+                                     widget)))
                (choice (const :tag "Ascending" nil)
                        (const :tag "Descending" t))))
 

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -126,14 +126,11 @@ Execute BODY in a buffer named with the help of NAME."
       (js-mode)
       (view-mode))))
 
-(defun docker-utils-reorder-data (order-alist default-order-alist data)
-  "Reorder the DATA vector from the order in DEFAULT-ORDER-ALIST to that in ORDER-ALIST."
-  (let* ((ordered-columns (-map 'car order-alist))
-         (indices (--map
-                   (seq-position default-order-alist it (lambda (x y) (equal (car x) y)))
-                   ordered-columns)))
-
-  (seq-into (--keep (when it (aref data it)) indices) 'vector)))
+(defun docker-utils-human-size-predicate (a b)
+  "Sort A and B by image size."
+  (let* ((a-size (elt (cadr a) 4))
+         (b-size (elt (cadr b) 4)))
+    (< (docker-utils-human-size-to-bytes a-size) (docker-utils-human-size-to-bytes b-size))))
 
 (defun docker-utils-column-order-list-format (columns-spec)
   "Convert COLUMNS-SPEC (a list of plists) to 'tabulated-list-format' (a vector of (name width bool))."

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -132,7 +132,7 @@ Execute BODY in a buffer named with the help of NAME."
          (b-size (elt (cadr b) 4)))
     (< (docker-utils-human-size-to-bytes a-size) (docker-utils-human-size-to-bytes b-size))))
 
-(defun docker-utils-column-order-list-format (columns-spec)
+(defun docker-utils-column-spec-list-format (columns-spec)
   "Convert COLUMNS-SPEC (a list of plists) to 'tabulated-list-format' (a vector of (name width bool))."
   (seq-into
    (--map (list (plist-get it :name) (plist-get it :width) (or (plist-get it :sort) t)) columns-spec)
@@ -148,7 +148,7 @@ Execute BODY in a buffer named with the help of NAME."
   "Convert a LINE from \"docker ls\" to a `tabulated-list-entries' entry.
 
 LINE is expected to be a JSON formatted array, and COLUMN-SPECS is the relevant
-defcustom (e.g. `docker-image-column-order`) used to apply any custom format functions."
+defcustom (e.g. `docker-image-column-spec`) used to apply any custom format functions."
   (condition-case nil
       (let* ((data (json-read-from-string line)))
         ;; apply format function, if any
@@ -161,6 +161,27 @@ defcustom (e.g. `docker-image-column-order`) used to apply any custom format fun
         (list (aref data 0) (seq-drop data 1)))
     (json-readtable-error
      (error "Could not read following string as json:\n%s" line))))
+
+(defun docker-utils-column-spec-setter (sym new-value)
+  "Convert NEW-VALUE into a list of plists, then assign to SYM.
+
+If NEW-VALUE already looks like a list of plists, no conversion is performed and
+ NEW-VALUE is assigned to SYM unchanged.  This is expected to be used as the
+value of :set in a defcustom."
+  (let ((is-plist (plist-member (car new-value) :name))
+        (new-value-plist (--map
+                          (-interleave '(:name :width :template :sort :format) it)
+                          new-value)))
+    (set sym (if is-plist new-value new-value-plist))))
+
+(defun docker-utils-column-spec-getter (sym)
+  "Convert the value of SYM for displaying in the customization menu.
+
+Just strips the plist symbols and returns only values.
+This has no effect on the actual value of the variable."
+  (--map
+   (-map (-partial #'plist-get it) '(:name :width :template :sort :format))
+   (symbol-value sym)))
 
 (provide 'docker-utils)
 

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -126,6 +126,32 @@ Execute BODY in a buffer named with the help of NAME."
       (js-mode)
       (view-mode))))
 
+;; TODO allow passing nil or empty string to remove a column, use -keep
+(defun docker-utils-reorder-data (order-alist default-order-alist data)
+  "Reorder the DATA vector from the order in DEFAULT-ORDER-ALIST to that in ORDER-ALIST."
+  (let* ((ordered-columns (-map 'car order-alist))
+         (indices (--map
+                   (seq-position default-order-alist it (lambda (x y) (equal (car x) y)))
+                   ordered-columns)))
+
+  (seq-into (--map (aref data it) indices) 'vector)))
+
+
+(defun docker-utils-sort-key-customize-type (columns-alist)
+  "Make the customize type descriptor from COLUMNS-ALIST, whose keys should be the column headers."
+  (let ((column-names (-map (lambda (x) (list 'const (car x))) columns-alist)))
+  `(cons
+    ,(cons 'choice column-names)
+    (choice (const :tag "Ascending" nil)
+            (const :tag "Descending" t)))))
+
+(defun docker-utils-column-order-customize-type (columns-alist)
+  "Make the customize type descriptor from COLUMNS-ALIST, whose keys should be the column headers."
+  (let ((column-names (-map (lambda (x) (list 'const (car x))) columns-alist)))
+    (cons
+     'list
+     (make-list (length columns-alist) `(cons ,(cons 'choice column-names) (integer))))))
+
 (provide 'docker-utils)
 
 ;;; docker-utils.el ends here

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -81,28 +81,12 @@ The order of entries defines the displayed column order.
                        (sexp :tag "Sort function")
                        (sexp :tag "Format function"))))
 
-;; TODO copied from docker-image
-(defun docker-volume-parse (column-specs line)
-  "Convert a LINE from \"docker volume ls\" to a `tabulated-list-entries' entry."
-  (condition-case nil
-      (let* ((data (json-read-from-string line)))
-        ;; apply format function, if any
-        (--each-indexed
-            column-specs
-          (let ((fmt-fn (plist-get it :format))
-                (data-index (+ it-index 1)))
-            (when fmt-fn (aset data data-index (apply fmt-fn (list (aref data data-index)))))))
-
-        (list (aref data 0) (seq-drop data 1)))
-    (json-readtable-error
-     (error "Could not read following string as json:\n%s" line))))
-
 (defun docker-volume-entries ()
   "Return the docker volumes data for `tabulated-list-entries'."
   (let* ((fmt (docker-utils-make-format-string docker-volume-id-template docker-volume-column-order))
          (data (docker-run-docker "volume ls" (docker-volume-ls-arguments) (format "--format=\"%s\"" fmt)))
          (lines (s-split "\n" data t)))
-    (-map (-partial #'docker-volume-parse docker-volume-column-order) lines)))
+    (-map (-partial #'docker-utils-parse docker-volume-column-order) lines)))
 
 (defun docker-volume-refresh ()
   "Refresh the volumes list."

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -139,7 +139,7 @@ and FLIP is a boolean to specify the sort order."
 
 (define-derived-mode docker-volume-mode tabulated-list-mode "Volumes Menu"
   "Major mode for handling a list of docker volumes."
-  (setq tabulated-list-format (seq-into (--map (list (car it) (cdr it) t) docker-volume-column-order) 'vector))
+  (setq tabulated-list-format (docker-utils-column-order-list-format docker-volume-column-order))
   (setq tabulated-list-padding 2)
   (setq tabulated-list-sort-key docker-volume-default-sort-key)
   (add-hook 'tabulated-list-revert-hook 'docker-volume-refresh nil t)

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -47,7 +47,11 @@ This should be a cons cell (NAME . FLIP) where
 NAME is a string matching one of the column names
 and FLIP is a boolean to specify the sort order."
   :group 'docker-volume
-  :type '(cons (string :tag "Column Name")
+  :type '(cons (string :tag "Column Name"
+                       :validate (lambda (widget)
+                                   (unless (--any-p (equal (plist-get it :name) (widget-value widget)) docker-volume-column-spec)
+                                     (widget-put widget :error "Default Sort Key must match a column name")
+                                     widget)))
                (choice (const :tag "Ascending" nil)
                        (const :tag "Descending" t))))
 


### PR DESCRIPTION
Allows setting an order for columns with a defcustom per mode. You can also hide columns if you choose, and set column widths.
Added this to containers, images, networks and volumes.

**Implementation notes:**
I added a default order alist that matches the data order of the format string in `docker-X-entries`. 
This alist is also used as the default value for the defcustom `docker-X-column-order`.

Then `docker-X-parse` computes the reordering by matching the default order with the user's specified order and permutes the data to match.

The tablist headers are computed from `docker-X-column-order` too.

Both of these steps are implement with common functions in `docker-utils`.

**Specific feedback**
- My elisp is still pretty rough, in particular I feel that the four new `docker-util` functions could be improved.
- Should the contents of `docker-X-column-order` match the format of `tabulated-list-format`? This would remove the need for `docker-utils-column-order-list-format`, but would complicate the presentation of the customize widget. (That's why I didn't implement it like that in the first place).
