### PR TITLE
Mark dangling images, volumes and networks

### DIFF
--- a/docker-image.el
+++ b/docker-image.el
@@ -169,6 +169,21 @@ The result is the tabulated list id for an entry is propertized with
     (docker-run-docker "tag" it (read-string (format "Tag for %s: " it))))
   (tablist-revert))
 
+(defun docker-image-mark-dangling ()
+  "Mark only the dangling images listed in *docker-images*.
+
+This clears any user marks first and respects any tablist filters
+applied to the buffer."
+  (interactive)
+  (switch-to-buffer "*docker-images*")
+  (tablist-unmark-all-marks)
+  (save-excursion
+    (goto-char (point-min))
+    (while (not (eobp))
+      (when (docker-image-dangling-p (tabulated-list-get-id))
+        (tablist-put-mark))
+      (forward-line))))
+
 (defun docker-image-ls-arguments ()
   "Return the latest used arguments in the `docker-image-ls' transient."
   (car (alist-get 'docker-image-ls transient-history)))
@@ -251,13 +266,14 @@ The result is the tabulated list id for an entry is propertized with
 (transient-define-prefix docker-image-help ()
   "Help transient for docker images."
   ["Docker images help"
-   ("D" "Remove"  docker-image-rm)
-   ("F" "Pull"    docker-image-pull)
-   ("I" "Inspect" docker-utils-inspect)
-   ("P" "Push"    docker-image-push)
-   ("R" "Run"     docker-image-run)
-   ("T" "Tag"     docker-image-tag-selection)
-   ("l" "List"    docker-image-ls)])
+   ("D" "Remove"        docker-image-rm)
+   ("F" "Pull"          docker-image-pull)
+   ("I" "Inspect"       docker-utils-inspect)
+   ("P" "Push"          docker-image-push)
+   ("R" "Run"           docker-image-run)
+   ("T" "Tag"           docker-image-tag-selection)
+   ("d" "Mark Dangling" docker-image-mark-dangling)
+   ("l" "List"          docker-image-ls)])
 
 (defvar docker-image-mode-map
   (let ((map (make-sparse-keymap)))
@@ -268,6 +284,7 @@ The result is the tabulated list id for an entry is propertized with
     (define-key map "P" 'docker-image-push)
     (define-key map "R" 'docker-image-run)
     (define-key map "T" 'docker-image-tag-selection)
+    (define-key map "d" 'docker-image-mark-dangling)
     (define-key map "l" 'docker-image-ls)
     map)
   "Keymap for `docker-image-mode'.")

--- a/docker-network.el
+++ b/docker-network.el
@@ -123,6 +123,21 @@ The result is the tabulated list id for an entry is propertized with
   "Read a network name."
   (completing-read "Network: " (-map #'car (docker-network-entries))))
 
+(defun docker-network-mark-dangling ()
+  "Mark only the dangling networks listed in *docker-networks*.
+
+This clears any user marks first and respects any tablist filters
+applied to the buffer."
+  (interactive)
+  (switch-to-buffer "*docker-networks*")
+  (tablist-unmark-all-marks)
+  (save-excursion
+    (goto-char (point-min))
+    (while (not (eobp))
+      (when (docker-network-dangling-p (tabulated-list-get-id))
+        (tablist-put-mark))
+      (forward-line))))
+
 (defun docker-network-ls-arguments ()
   "Return the latest used arguments in the `docker-network-ls' transient."
   (car (alist-get 'docker-network-ls transient-history)))
@@ -146,16 +161,18 @@ The result is the tabulated list id for an entry is propertized with
 (transient-define-prefix docker-network-help ()
   "Help transient for docker networks."
   ["Docker networks help"
-   ("D" "Remove"     docker-network-rm)
-   ("I" "Inspect"    docker-utils-inspect)
-   ("l" "List"       docker-network-ls)])
+   ("D" "Remove"        docker-network-rm)
+   ("I" "Inspect"       docker-utils-inspect)
+   ("d" "Mark Dangling" docker-network-mark-dangling)
+   ("l" "List"          docker-network-ls)])
 
 (defvar docker-network-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "?" 'docker-network-help)
     (define-key map "D" 'docker-network-rm)
-    (define-key map "l" 'docker-network-ls)
     (define-key map "I" 'docker-utils-inspect)
+    (define-key map "d" 'docker-network-mark-dangling)
+    (define-key map "l" 'docker-network-ls)
     map)
   "Keymap for `docker-network-mode'.")
 

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -135,6 +135,21 @@ The result is the tabulated list id for an entry is propertized with
   (--each (docker-utils-get-marked-items-ids)
     (docker-volume-dired it)))
 
+(defun docker-volume-mark-dangling ()
+  "Mark only the dangling volumes listed in *docker-volumes*.
+
+This clears any user marks first and respects any tablist filters
+applied to the buffer."
+  (interactive)
+  (switch-to-buffer "*docker-volumes*")
+  (tablist-unmark-all-marks)
+  (save-excursion
+    (goto-char (point-min))
+    (while (not (eobp))
+      (when (docker-volume-dangling-p (tabulated-list-get-id))
+        (tablist-put-mark))
+      (forward-line))))
+
 (defun docker-volume-ls-arguments ()
   "Return the latest used arguments in the `docker-volume-ls' transient."
   (car (alist-get 'docker-volume-ls transient-history)))
@@ -157,18 +172,20 @@ The result is the tabulated list id for an entry is propertized with
 (transient-define-prefix docker-volume-help ()
   "Help transient for docker volumes."
   ["Docker volumes help"
-   ("D" "Remove"     docker-volume-rm)
-   ("d" "Dired"      docker-volume-dired-selection)
-   ("I" "Inspect"    docker-utils-inspect)
-   ("l" "List"       docker-volume-ls)])
+   ("D" "Remove"        docker-volume-rm)
+   ("I" "Inspect"       docker-utils-inspect)
+   ("d" "Mark Dangling" docker-volume-mark-dangling)
+   ("f" "Dired"         docker-volume-dired-selection)
+   ("l" "List"          docker-volume-ls)])
 
 (defvar docker-volume-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "?" 'docker-volume-help)
     (define-key map "D" 'docker-volume-rm)
-    (define-key map "d" 'docker-volume-dired-selection)
-    (define-key map "l" 'docker-volume-ls)
     (define-key map "I" 'docker-utils-inspect)
+    (define-key map "d" 'docker-volume-mark-dangling)
+    (define-key map "f" 'docker-volume-dired-selection)
+    (define-key map "l" 'docker-volume-ls)
     map)
   "Keymap for `docker-volume-mode'.")
 


### PR DESCRIPTION
Adds a command to mark dangling things in each of the buffer views.

Although the same could be accomplished by doing the key sequence `l d l t` (i.e list filter dangling followed by tablist invert mark), this speeds up the process and makes it more obvious how to do "prune" from the main help transient.

