### PR TITLE
Feature/docker run async

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -212,14 +212,14 @@ nil, ask the user for it."
   (interactive "sContainer path: \nFHost path: ")
   (docker-utils-ensure-items)
   (--each (docker-utils-get-marked-items-ids)
-    (docker-run-docker "cp" (concat it ":" container-path) host-path)))
+    (docker-run-async (list "cp" (concat it ":" container-path) host-path))))
 
 (defun docker-container-cp-to-selection (host-path container-path)
   "Run \"docker cp\" from HOST-PATH to CONTAINER-PATH for selected containers."
   (interactive "fHost path: \nsContainer path: ")
   (docker-utils-ensure-items)
   (--each (docker-utils-get-marked-items-ids)
-    (docker-run-docker "cp" host-path (concat it ":" container-path))))
+    (docker-run-async (list "cp" host-path (concat it ":" container-path)))))
 
 (defun docker-container-eshell-selection ()
   "Run `docker-container-eshell' on the containers selection."
@@ -246,9 +246,7 @@ nil, ask the user for it."
   "Rename containers."
   (interactive)
   (docker-utils-ensure-items)
-  (--each (docker-utils-get-marked-items-ids)
-    (docker-run-docker "rename" it (read-string (format "Rename \"%s\" to: " it))))
-  (tablist-revert))
+  (docker-utils-generic-action-async (format "rename %s" it) (read-string (format "Rename \"%s\" to: " it))))
 
 (defun docker-container-shell-selection (prefix)
   "Run `docker-container-shell' on the containers selection."
@@ -268,9 +266,7 @@ nil, ask the user for it."
   "Run `docker-container-unpause' on the containers selection."
   (interactive)
   (docker-utils-ensure-items)
-  (--each (docker-utils-get-marked-items-ids)
-    (docker-run-docker "unpause" it))
-  (tablist-revert))
+  (docker-utils-generic-action-async (format "unpause %s" it) ()))
 
 (docker-utils-transient-define-prefix docker-container-attach ()
   "Transient for attaching to containers."
@@ -306,7 +302,7 @@ nil, ask the user for it."
   ["Arguments"
    ("s" "Signal" "-s " read-string)]
   [:description docker-utils-generic-actions-heading
-   ("K" "Kill" docker-utils-generic-action)])
+   ("K" "Kill" docker-utils-generic-action-async)])
 
 (docker-utils-transient-define-prefix docker-container-logs ()
   "Transient for showing containers logs."
@@ -340,7 +336,7 @@ nil, ask the user for it."
   "Transient for pauseing containers."
   :man-page "docker-container-pause"
   [:description docker-utils-generic-actions-heading
-   ("P" "Pause" docker-utils-generic-action)
+   ("P" "Pause" docker-utils-generic-action-async)
    ("U" "Unpause" docker-container-unpause-selection)])
 
 (docker-utils-transient-define-prefix docker-container-restart ()
@@ -349,7 +345,7 @@ nil, ask the user for it."
   ["Arguments"
    ("t" "Timeout" "-t " transient-read-number-N0)]
   [:description docker-utils-generic-actions-heading
-   ("R" "Restart" docker-utils-generic-action)])
+   ("R" "Restart" docker-utils-generic-action-async)])
 
 (docker-utils-transient-define-prefix docker-container-rm ()
   "Transient for removing containers."
@@ -358,7 +354,7 @@ nil, ask the user for it."
    ("f" "Force" "-f")
    ("v" "Volumes" "-v")]
   [:description docker-utils-generic-actions-heading
-   ("D" "Remove" docker-utils-generic-action)])
+   ("D" "Remove" docker-utils-generic-action-async)])
 
 (docker-utils-transient-define-prefix docker-container-shells ()
   "Transient for doing M-x `shell'/`eshell' to containers."
@@ -371,7 +367,7 @@ nil, ask the user for it."
   "Transient for starting containers."
   :man-page "docker-container-start"
   [:description docker-utils-generic-actions-heading
-   ("S" "Start" docker-utils-generic-action)])
+   ("S" "Start" docker-utils-generic-action-async)])
 
 (docker-utils-transient-define-prefix docker-container-stop ()
   "Transient for stoping containers."
@@ -379,7 +375,7 @@ nil, ask the user for it."
   ["Arguments"
    ("t" "Timeout" "-t " transient-read-number-N0)]
   [:description docker-utils-generic-actions-heading
-   ("O" "Stop" docker-utils-generic-action)])
+   ("O" "Stop" docker-utils-generic-action-async)])
 
 (transient-define-prefix docker-container-help ()
   "Help transient for docker containers."

--- a/docker-container.el
+++ b/docker-container.el
@@ -255,7 +255,6 @@ nil, ask the user for it."
   "Rename containers."
   (interactive)
   (docker-utils-ensure-items)
-  ;; TODO I assume since renaming is interactive, that it doesn't need to be async
   (--each (docker-utils-get-marked-items-ids)
     (docker-run-docker "rename" it (read-string (format "Rename \"%s\" to: " it))))
   (tablist-revert))

--- a/docker-container.el
+++ b/docker-container.el
@@ -246,7 +246,9 @@ nil, ask the user for it."
   "Rename containers."
   (interactive)
   (docker-utils-ensure-items)
-  (docker-utils-generic-action-async (format "rename %s" it) (read-string (format "Rename \"%s\" to: " it))))
+  (--each (docker-utils-get-marked-items-ids)
+    (docker-run-docker "rename" it (read-string (format "Rename \"%s\" to: " it))))
+  (tablist-revert))
 
 (defun docker-container-shell-selection (prefix)
   "Run `docker-container-shell' on the containers selection."
@@ -266,7 +268,7 @@ nil, ask the user for it."
   "Run `docker-container-unpause' on the containers selection."
   (interactive)
   (docker-utils-ensure-items)
-  (docker-utils-generic-action-async (format "unpause %s" it) ()))
+  (docker-utils-generic-action-merged "unpause" (transient-args transient-current-command)))
 
 (docker-utils-transient-define-prefix docker-container-attach ()
   "Transient for attaching to containers."
@@ -302,7 +304,7 @@ nil, ask the user for it."
   ["Arguments"
    ("s" "Signal" "-s " read-string)]
   [:description docker-utils-generic-actions-heading
-   ("K" "Kill" docker-utils-generic-action-async)])
+   ("K" "Kill" docker-utils-generic-action-merged)])
 
 (docker-utils-transient-define-prefix docker-container-logs ()
   "Transient for showing containers logs."
@@ -336,7 +338,7 @@ nil, ask the user for it."
   "Transient for pausing containers."
   :man-page "docker-container-pause"
   [:description docker-utils-generic-actions-heading
-   ("P" "Pause" docker-utils-generic-action-async)
+   ("P" "Pause" docker-utils-generic-action-merged)
    ("U" "Unpause" docker-container-unpause-selection)])
 
 (docker-utils-transient-define-prefix docker-container-restart ()
@@ -345,7 +347,7 @@ nil, ask the user for it."
   ["Arguments"
    ("t" "Timeout" "-t " transient-read-number-N0)]
   [:description docker-utils-generic-actions-heading
-   ("R" "Restart" docker-utils-generic-action-async)])
+   ("R" "Restart" docker-utils-generic-action-merged)])
 
 (docker-utils-transient-define-prefix docker-container-rm ()
   "Transient for removing containers."
@@ -354,7 +356,7 @@ nil, ask the user for it."
    ("f" "Force" "-f")
    ("v" "Volumes" "-v")]
   [:description docker-utils-generic-actions-heading
-   ("D" "Remove" docker-utils-generic-action-async)])
+   ("D" "Remove" docker-utils-generic-action-merged)])
 
 (docker-utils-transient-define-prefix docker-container-shells ()
   "Transient for doing M-x `shell'/`eshell' to containers."
@@ -367,7 +369,7 @@ nil, ask the user for it."
   "Transient for starting containers."
   :man-page "docker-container-start"
   [:description docker-utils-generic-actions-heading
-   ("S" "Start" docker-utils-generic-action-async)])
+   ("S" "Start" docker-utils-generic-action-merged)])
 
 (docker-utils-transient-define-prefix docker-container-stop ()
   "Transient for stoping containers."
@@ -375,7 +377,7 @@ nil, ask the user for it."
   ["Arguments"
    ("t" "Timeout" "-t " transient-read-number-N0)]
   [:description docker-utils-generic-actions-heading
-   ("O" "Stop" docker-utils-generic-action-async)])
+   ("O" "Stop" docker-utils-generic-action-merged)])
 
 (transient-define-prefix docker-container-help ()
   "Help transient for docker containers."

--- a/docker-container.el
+++ b/docker-container.el
@@ -333,7 +333,7 @@ nil, ask the user for it."
    ("l" "List" tablist-revert)])
 
 (docker-utils-transient-define-prefix docker-container-pause ()
-  "Transient for pauseing containers."
+  "Transient for pausing containers."
   :man-page "docker-container-pause"
   [:description docker-utils-generic-actions-heading
    ("P" "Pause" docker-utils-generic-action-async)
@@ -379,22 +379,24 @@ nil, ask the user for it."
 
 (transient-define-prefix docker-container-help ()
   "Help transient for docker containers."
-  ["Docker containers help"
-   ("C" "Copy"       docker-container-cp)
-   ("D" "Remove"     docker-container-rm)
-   ("I" "Inspect"    docker-utils-inspect)
-   ("K" "Kill"       docker-container-kill)
-   ("L" "Logs"       docker-container-logs)
-   ("O" "Stop"       docker-container-stop)
-   ("P" "Pause"      docker-container-pause)
-   ("R" "Restart"    docker-container-restart)
-   ("S" "Start"      docker-container-start)
-   ("a" "Attach"     docker-container-attach)
-   ("b" "Shell"      docker-container-shells)
-   ("d" "Diff"       docker-container-diff)
-   ("f" "Find file"  docker-container-open)
-   ("l" "List"       docker-container-ls)
-   ("r" "Rename"     docker-container-rename-selection)])
+  ["Docker Containers"
+   ["Lifecycle"
+    ("K" "Kill"       docker-container-kill)
+    ("O" "Stop"       docker-container-stop)
+    ("P" "Pause"      docker-container-pause)
+    ("R" "Restart"    docker-container-restart)
+    ("S" "Start"      docker-container-start)]
+   ["Admin"
+    ("C" "Copy"       docker-container-cp)
+    ("D" "Remove"     docker-container-rm)
+    ("I" "Inspect"    docker-utils-inspect)
+    ("L" "Logs"       docker-container-logs)
+    ("a" "Attach"     docker-container-attach)
+    ("b" "Shell"      docker-container-shells)
+    ("d" "Diff"       docker-container-diff)
+    ("f" "Find file"  docker-container-open)
+    ("l" "List"       docker-container-ls)
+    ("r" "Rename"     docker-container-rename-selection)]])
 
 (defvar docker-container-mode-map
   (let ((map (make-sparse-keymap)))

--- a/docker-container.el
+++ b/docker-container.el
@@ -279,7 +279,7 @@ nil, ask the user for it."
    ("n" "No STDIN" "--no-stdin")
    ("d" "Key sequence for detaching" "--detach-keys=" read-string)]
   [:description docker-utils-generic-actions-heading
-   ("a" "Attach" docker-utils-generic-action-async)])
+   ("a" "Attach" docker-utils-generic-action-with-buffer)])
 
 (docker-utils-transient-define-prefix docker-container-cp ()
   "Transient for copying files from/to containers."
@@ -317,7 +317,7 @@ nil, ask the user for it."
    ("t" "Tail" "--tail " read-string)
    ("u" "Until" "--until " read-string)]
   [:description docker-utils-generic-actions-heading
-   ("L" "Logs" docker-utils-generic-action-async)])
+   ("L" "Logs" docker-utils-generic-action-with-buffer)])
 
 (defun docker-container-ls-arguments ()
   "Return the latest used arguments in the `docker-container-ls' transient."

--- a/docker-container.el
+++ b/docker-container.el
@@ -402,6 +402,7 @@ nil, ask the user for it."
 
 (defvar docker-container-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map "$" 'docker-utils-visit-error-buffer)
     (define-key map "?" 'docker-container-help)
     (define-key map "C" 'docker-container-cp)
     (define-key map "D" 'docker-container-rm)

--- a/docker-core.el
+++ b/docker-core.el
@@ -119,7 +119,7 @@ finished."
     ('"finished\n"
      (apply callback (list (process-buffer proc))))
     (_
-     (message (format "%s: %s\nSee buffer %s" (process-name proc) status (buffer-name (process-buffer proc))))
+     (message (format "%s: %s\nPress $ or visit buffer %s" (process-name proc) status (buffer-name (process-buffer proc))))
      (push (process-buffer proc) docker-error-buffers))))
 
 (defun docker-generate-new-buffer-name (&rest args)

--- a/docker-core.el
+++ b/docker-core.el
@@ -69,16 +69,21 @@ Wrap the function `shell-command-to-string', ensuring variable `shell-file-name'
       (message command)
       (s-trim-right (docker-shell-command-to-string command)))))
 
-(defun docker-run-attached (&rest args)
-  "Execute \"`docker-command' ARGS\" using `async-shell-command'."
-  (docker-with-sudo
-    (let* ((flat-args (-remove 's-blank? (-flatten (list (docker-arguments) args))))
-           (command (s-join " " (cons docker-command flat-args))))
-      (message command)
-      (async-shell-command command (docker-generate-new-buffer-name (s-join " " flat-args))))))
+(defun docker-run-with-buffer (&rest args)
+  "Execute \"`docker-command' ARGS\" displaying output in a new buffer.
+
+See `docker-run-async'."
+  (docker-run-async
+   args
+   (lambda (data-buffer)
+     (switch-to-buffer data-buffer))))
 
 (defun docker-run-async (args &optional callback)
-  "ARGS is a list of arguments to the 'docker' command."
+  "Run \"`docker-command' ARGS\" in an external process then call CALLBACK.
+
+ARGS is a list of arguments to the 'docker' command.
+CALLBACK should accept the output buffer.  It is called only when the process is
+finished."
   (docker-with-sudo
     (let* ((flat-args (-remove 's-blank? (-flatten (list (docker-arguments) args))))
            (command-list (cons docker-command flat-args))

--- a/docker-core.el
+++ b/docker-core.el
@@ -69,11 +69,11 @@ Wrap the function `shell-command-to-string', ensuring variable `shell-file-name'
       (message command)
       (s-trim-right (docker-shell-command-to-string command)))))
 
-(defun docker-run-docker-async (&rest args)
+(defun docker-run-attached (&rest args)
   "Execute \"`docker-command' ARGS\" using `async-shell-command'."
   (docker-with-sudo
     (let* ((flat-args (-remove 's-blank? (-flatten (list (docker-arguments) args))))
-           (command (s-join " " (-insert-at 0 docker-command flat-args))))
+           (command (s-join " " (cons docker-command flat-args))))
       (message command)
       (async-shell-command command (docker-generate-new-buffer-name (s-join " " flat-args))))))
 

--- a/docker-core.el
+++ b/docker-core.el
@@ -77,7 +77,7 @@ Wrap the function `shell-command-to-string', ensuring variable `shell-file-name'
       (message command)
       (async-shell-command command (docker-generate-new-buffer-name (s-join " " flat-args))))))
 
-(defun docker-run-async (args callback)
+(defun docker-run-async (args &optional callback)
   "ARGS is a list of arguments to the 'docker' command."
   (docker-with-sudo
     (let* ((flat-args (-remove 's-blank? (-flatten (list (docker-arguments) args))))
@@ -85,6 +85,8 @@ Wrap the function `shell-command-to-string', ensuring variable `shell-file-name'
            (command-string (s-join " " command-list))
            (output-buffer-name (docker-generate-new-buffer-name (s-join " " flat-args))))
       (message command-string)
+      (unless callback
+        (setq callback #'kill-buffer))
       (make-process
        :name command-string
        :buffer output-buffer-name
@@ -93,9 +95,9 @@ Wrap the function `shell-command-to-string', ensuring variable `shell-file-name'
        :noquery t))))
 
 (defun docker-process-sentinel (callback proc status)
-  "Passes command output buffer to CALLBACK"
+  "Passes command output buffer to CALLBACK."
   (pcase status
-    ('"finished\n" (apply callback (list (process-buffer proc)))) ;; TODO cleanup?
+    ('"finished\n" (apply callback (list (process-buffer proc))))
     (_ (message (format "%s: %s" (process-name proc) status)))))
 
 (defun docker-generate-new-buffer-name (&rest args)

--- a/docker-core.el
+++ b/docker-core.el
@@ -41,6 +41,9 @@
   :group 'docker
   :type 'boolean)
 
+(defvar docker-error-buffers ()
+  "Buffers with error output from Docker commands.")
+
 (defun docker-arguments ()
   "Return the latest used arguments in the `docker' transient."
   (car (alist-get 'docker transient-history)))
@@ -113,8 +116,11 @@ finished."
 (defun docker-process-sentinel (callback proc status)
   "Passes command output buffer to CALLBACK."
   (pcase status
-    ('"finished\n" (apply callback (list (process-buffer proc))))
-    (_ (message (format "%s: %s" (process-name proc) status)))))
+    ('"finished\n"
+     (apply callback (list (process-buffer proc))))
+    (_
+     (message (format "%s: %s\nSee buffer %s" (process-name proc) status (buffer-name (process-buffer proc))))
+     (push (process-buffer proc) docker-error-buffers))))
 
 (defun docker-generate-new-buffer-name (&rest args)
   "Wrapper around `generate-new-buffer-name'."

--- a/docker-core.el
+++ b/docker-core.el
@@ -76,10 +76,11 @@ Wrap the function `shell-command-to-string', ensuring variable `shell-file-name'
   "Execute \"`docker-command' ARGS\" displaying output in a new buffer.
 
 See `docker-run-async'."
-  (docker-run-async
-   args
-   (lambda (data-buffer)
-     (switch-to-buffer data-buffer))))
+  (let ((process (docker-run-async
+                  args
+                  (lambda (_) (message "Docker process Finished")))))
+    (switch-to-buffer-other-window (process-buffer process))
+    process))
 
 (defun docker-run-async (args &optional callback)
   "Run \"`docker-command' ARGS\" in an external process then call CALLBACK.

--- a/docker-image.el
+++ b/docker-image.el
@@ -299,6 +299,7 @@ applied to the buffer."
 
 (defvar docker-image-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map "$" 'docker-utils-visit-error-buffer)
     (define-key map "?" 'docker-image-help)
     (define-key map "D" 'docker-image-rm)
     (define-key map "F" 'docker-image-pull)

--- a/docker-image.el
+++ b/docker-image.el
@@ -243,7 +243,7 @@ applied to the buffer."
    ("-f" "Force" "-f")
    ("-n" "Don't prune" "--no-prune")]
   [:description docker-utils-generic-actions-heading
-   ("D" "Remove" docker-utils-generic-action-async)])
+   ("D" "Remove" docker-utils-generic-action-merged)])
 
 (defclass docker-run-prefix (transient-prefix) nil)
 

--- a/docker-network.el
+++ b/docker-network.el
@@ -168,6 +168,7 @@ applied to the buffer."
 
 (defvar docker-network-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map "$" 'docker-utils-visit-error-buffer)
     (define-key map "?" 'docker-network-help)
     (define-key map "D" 'docker-network-rm)
     (define-key map "I" 'docker-utils-inspect)

--- a/docker-network.el
+++ b/docker-network.el
@@ -156,7 +156,7 @@ applied to the buffer."
   "Transient for removing networks."
   :man-page "docker-network-rm"
   [:description docker-utils-generic-actions-heading
-   ("D" "Remove" docker-utils-generic-action)])
+   ("D" "Remove" docker-utils-generic-action-async)])
 
 (transient-define-prefix docker-network-help ()
   "Help transient for docker networks."

--- a/docker-network.el
+++ b/docker-network.el
@@ -156,7 +156,7 @@ applied to the buffer."
   "Transient for removing networks."
   :man-page "docker-network-rm"
   [:description docker-utils-generic-actions-heading
-   ("D" "Remove" docker-utils-generic-action-async)])
+   ("D" "Remove" docker-utils-generic-action-merged)])
 
 (transient-define-prefix docker-network-help ()
   "Help transient for docker networks."

--- a/docker-network.el
+++ b/docker-network.el
@@ -106,14 +106,26 @@ The result is the tabulated list id for an entry is propertized with
   (list (propertize (car parsed-entry) 'docker-network-dangling t)
         (apply #'vector (--map (propertize it 'font-lock-face 'docker-face-dangling) (cadr parsed-entry)))))
 
-(defun docker-network-description-with-stats ()
-  "Return the networks stats string."
-  (let* ((inhibit-message t)
-         (entries (docker-network-entries-propertized))
-         (dangling (-filter (-compose #'docker-network-dangling-p 'car) entries)))
-    (format "Networks (%s total, %s dangling)"
-            (length entries)
-            (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling))))
+(defun docker-network-fetch-status-async ()
+  "Write the status to `docker-status-strings'."
+  (docker-run-async
+    '("network" "ls" "-q" "--filter=\ dangling=true")
+    (lambda (data-buffer)
+      (let* ((dangling (with-current-buffer data-buffer (length (s-split "\n" (buffer-string) t)))))
+        (kill-buffer data-buffer)
+        ;; now it gets crazy...
+        (docker-run-async
+         '("network" "ls" "-q")
+         (lambda (data-buffer)
+           (let* ((all (with-current-buffer data-buffer (length (s-split "\n" (buffer-string) t)))))
+             (push `(network . ,(format "%s total, %s dangling"
+                                      (number-to-string all)
+                                      (propertize (number-to-string dangling) 'face 'docker-face-dangling)))
+                   docker-status-strings)
+             (kill-buffer data-buffer)
+             (transient--redisplay))))))))
+
+(add-hook 'docker-open-hook #'docker-network-fetch-status-async)
 
 (defun docker-network-refresh ()
   "Refresh the networks list."

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -93,15 +93,6 @@ Execute BODY in a buffer named with the help of NAME."
                           (with-current-buffer calling-buffer (tablist-revert))
                           (kill-buffer data-buffer))))))
 
-(defun docker-utils-generic-action-with-buffer:json (action args)
-  (interactive (list (docker-utils-get-transient-action)
-                     (transient-args transient-current-command)))
-  (--each (docker-utils-get-marked-items-ids)
-    (docker-utils-with-buffer (format "%s %s" action it)
-      (insert (docker-run-docker action args it))
-      (json-mode)))
-  (tablist-revert))
-
 (defun docker-utils-pop-to-buffer (name)
   "Like `pop-to-buffer', but suffix NAME with the host if on a remote host."
   (pop-to-buffer

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -80,8 +80,7 @@ Execute BODY in a buffer named with the help of NAME."
   (interactive (list (docker-utils-get-transient-action)
                      (transient-args transient-current-command)))
   (--each (docker-utils-get-marked-items-ids)
-    (docker-run-with-buffer (s-split " " action) args it))
-  (tablist-revert))
+    (docker-run-with-buffer (s-split " " action) args it)))
 
 (defun docker-utils-generic-action-async (action args)
   (interactive (list (docker-utils-get-transient-action)

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -80,7 +80,7 @@ Execute BODY in a buffer named with the help of NAME."
   (interactive (list (docker-utils-get-transient-action)
                      (transient-args transient-current-command)))
   (--each (docker-utils-get-marked-items-ids)
-    (docker-run-attached action args it))
+    (docker-run-with-buffer (s-split " " action) args it))
   (tablist-revert))
 
 (defun docker-utils-generic-action-async (action args)

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -83,6 +83,16 @@ Execute BODY in a buffer named with the help of NAME."
     (docker-run-attached action args it))
   (tablist-revert))
 
+(defun docker-utils-generic-action-async (action args)
+  (interactive (list (docker-utils-get-transient-action)
+                     (transient-args transient-current-command)))
+  (--each (docker-utils-get-marked-items-ids)
+    (let ((calling-buffer (current-buffer)))
+      (docker-run-async (list (s-split " " action) args (list it))
+                        (lambda (data-buffer)
+                          (with-current-buffer calling-buffer (tablist-revert))
+                          (kill-buffer data-buffer))))))
+
 (defun docker-utils-generic-action-with-buffer:json (action args)
   (interactive (list (docker-utils-get-transient-action)
                      (transient-args transient-current-command)))

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -75,19 +75,12 @@ Execute BODY in a buffer named with the help of NAME."
     (docker-run-docker action args it))
   (tablist-revert))
 
-(defun docker-utils-generic-action-async (action args)
-  (interactive (list (docker-utils-get-transient-action)
-                     (transient-args transient-current-command)))
-  (--each (docker-utils-get-marked-items-ids)
-    (docker-run-docker-async action args it))
-  (tablist-revert))
-
 (defun docker-utils-generic-action-with-buffer (action args)
+  "Run 'docker ACTION ARGS' asynchronously, printing output to a new buffer."
   (interactive (list (docker-utils-get-transient-action)
                      (transient-args transient-current-command)))
   (--each (docker-utils-get-marked-items-ids)
-    (docker-utils-with-buffer (format "%s %s" action it)
-      (insert (docker-run-docker action args it))))
+    (docker-run-attached action args it))
   (tablist-revert))
 
 (defun docker-utils-generic-action-with-buffer:json (action args)

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -93,6 +93,16 @@ Execute BODY in a buffer named with the help of NAME."
                           (with-current-buffer calling-buffer (tablist-revert))
                           (kill-buffer data-buffer))))))
 
+(defun docker-utils-generic-action-merged (action args)
+  "As for `docker-utils-generic-action-async', but group selection ids into a single command."
+  (interactive (list (docker-utils-get-transient-action)
+                     (transient-args transient-current-command)))
+  (let ((calling-buffer (current-buffer)))
+    (docker-run-async (list (s-split " " action) args (docker-utils-get-marked-items-ids))
+                      (lambda (data-buffer)
+                        (with-current-buffer calling-buffer (tablist-revert))
+                        (kill-buffer data-buffer)))))
+
 (defun docker-utils-pop-to-buffer (name)
   "Like `pop-to-buffer', but suffix NAME with the host if on a remote host."
   (pop-to-buffer

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -167,7 +167,7 @@ applied to the buffer."
   "Transient for removing volumes."
   :man-page "docker-volume-rm"
   [:description docker-utils-generic-actions-heading
-   ("D" "Remove" docker-utils-generic-action-async)])
+   ("D" "Remove" docker-utils-generic-action-merged)])
 
 (transient-define-prefix docker-volume-help ()
   "Help transient for docker volumes."

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -167,7 +167,7 @@ applied to the buffer."
   "Transient for removing volumes."
   :man-page "docker-volume-rm"
   [:description docker-utils-generic-actions-heading
-   ("D" "Remove" docker-utils-generic-action)])
+   ("D" "Remove" docker-utils-generic-action-async)])
 
 (transient-define-prefix docker-volume-help ()
   "Help transient for docker volumes."

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -180,6 +180,7 @@ applied to the buffer."
 
 (defvar docker-volume-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map "$" 'docker-utils-visit-error-buffer)
     (define-key map "?" 'docker-volume-help)
     (define-key map "D" 'docker-volume-rm)
     (define-key map "I" 'docker-utils-inspect)

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -104,14 +104,26 @@ The result is the tabulated list id for an entry is propertized with
   (list (propertize (car parsed-entry) 'docker-volume-dangling t)
         (apply #'vector (--map (propertize it 'font-lock-face 'docker-face-dangling) (cadr parsed-entry)))))
 
-(defun docker-volume-description-with-stats ()
-  "Return the volumes stats string."
-  (let* ((inhibit-message t)
-         (entries (docker-volume-entries-propertized))
-         (dangling (-filter (-compose #'docker-volume-dangling-p 'car) entries)))
-    (format "Volumes (%s total, %s dangling)"
-            (length entries)
-            (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling))))
+(defun docker-volume-fetch-status-async ()
+  "Write the status to `docker-status-strings'."
+  (docker-run-async
+    '("volume" "ls" "-q" "--filter=\ dangling=true")
+    (lambda (data-buffer)
+      (let* ((dangling (with-current-buffer data-buffer (length (s-split "\n" (buffer-string) t)))))
+        (kill-buffer data-buffer)
+        ;; now it gets crazy...
+        (docker-run-async
+         '("volume" "ls" "-q")
+         (lambda (data-buffer)
+           (let* ((all (with-current-buffer data-buffer (length (s-split "\n" (buffer-string) t)))))
+             (push `(volume . ,(format "%s total, %s dangling"
+                                      (number-to-string all)
+                                      (propertize (number-to-string dangling) 'face 'docker-face-dangling)))
+                   docker-status-strings)
+             (kill-buffer data-buffer)
+             (transient--redisplay))))))))
+
+(add-hook 'docker-open-hook #'docker-volume-fetch-status-async)
 
 (defun docker-volume-refresh ()
   "Refresh the volumes list."

--- a/docker.el
+++ b/docker.el
@@ -56,7 +56,13 @@
 ;;;###autoload (autoload 'docker "docker" nil t)
 (defun docker ()
   (interactive)
-  ;; TODO perhaps reset status-strings here
+  ;; remove old status strings
+  (setq docker-status-strings
+        `((container . ,(or (alist-get 'container docker-status-strings) ""))
+          (image . ,(or (alist-get 'image docker-status-strings) ""))
+          (network . ,(or (alist-get 'network docker-status-strings) ""))
+          (volume . ,(or (alist-get 'volume docker-status-strings) ""))))
+
   (run-hooks 'docker-open-hook)
   (docker-transient))
 

--- a/docker.el
+++ b/docker.el
@@ -43,8 +43,24 @@
   "Wrapper around `read-file-name'."
   (read-file-name prompt nil nil t initial-input (apply-partially 'string-match ".*\\.pem")))
 
+(defvar docker-open-hook ()
+  "Called when Docker transient is openened.")
+
+(defvar docker-status-strings
+  '((container . "")
+    (image . "")
+    (network . "")
+    (volume . ""))
+  "Alist of status reports for `docker-transient'.")
+
 ;;;###autoload (autoload 'docker "docker" nil t)
-(transient-define-prefix docker ()
+(defun docker ()
+  (interactive)
+  ;; TODO perhaps reset status-strings here
+  (run-hooks 'docker-open-hook)
+  (docker-transient))
+
+(transient-define-prefix docker-transient ()
   "Transient for docker."
   :man-page "docker"
   ["Arguments"
@@ -56,10 +72,10 @@
    (5 "Tk" "TLS key" "--tlskey" docker-read-certificate)
    (5 "l" "Log level" "--log-level " docker-read-log-level)]
   ["Docker"
-   ("c" docker-container-description-with-stats docker-containers)
-   ("i" docker-image-description-with-stats     docker-images)
-   ("n" docker-network-description-with-stats   docker-networks)
-   ("v" docker-volume-description-with-stats    docker-volumes)]
+   ("c" (lambda ()(format "Containers (%s)" (alist-get 'container docker-status-strings))) docker-containers)
+   ("i" (lambda ()(format "Images (%s)" (alist-get 'image docker-status-strings)))         docker-images)
+   ("n" (lambda ()(format "Networks (%s)" (alist-get 'network docker-status-strings)))     docker-networks)
+   ("v" (lambda ()(format "Volumes (%s)" (alist-get 'volume docker-status-strings)))       docker-volumes)]
   ["Other"
    ("C" "Compose"    docker-compose)])
 


### PR DESCRIPTION
~~Mostly working, just need some testing and to cover #98 and #140 adequately.~~
See latest comment, waiting for feedback on functionality.

(I plan on doing docker-compose commands in a separate PR).
 
**Design**
Use `make-process` to start a process, and a process sentinel to listen for the process buffer to be ready. This is roughly how `magit-start-process` works, but our use cases are a bit different.

Transient commands which should be async fall in these categories
* "lifecycle" commands: do something to a container/image/volume and update the tablist
* buffer-generating commands: do something and output to a new buffer (possibly continuing), e.g. attach, logs
* tablist-generating commands: no examples yet, but consider `docker search`

So we can't really use a single process buffer as there can be multiple process buffers running in parallel.

Instead I passed a callback which will specialize `docker-run-async` to each of the cases above:
```elisp
(defun docker-run-async (args &optional callback)
  "ARGS is a list of arguments to the 'docker' command."
  (docker-with-sudo
       ;; clean up arguments
      (unless callback
        (setq callback #'kill-buffer))  ;; default behaviour is to discard output
      (make-process
       :name command-string
       :buffer output-buffer-name
       :command command-list
       :sentinel (-partial #'docker-process-sentinel callback)
       :noquery t))))

(defun docker-process-sentinel (callback proc status)
  "Passes command output buffer to CALLBACK."
  ;; includes error handling too
)
 ```
Now I can rewrite `docker-utils-generic-action` to be async and update the tablist:
```elisp
(defun docker-utils-generic-action-async (action args)
  (interactive (list (docker-utils-get-transient-action)
                     (transient-args transient-current-command)))
  (--each (docker-utils-get-marked-items-ids)
    (let ((calling-buffer (current-buffer)))
      (docker-run-async (list (s-split " " action) args (list it))
                        (lambda (data-buffer)
                          (with-current-buffer calling-buffer (tablist-revert))
                          (kill-buffer data-buffer))))))
```
This can be used exactly in place of existing uses of `docker-utils-generic-action` to make most actions async!
And, because the buffer is killed by the "finished" callback, stderr output is preserved in the process buffers.

Buffer-generating actions can be implemented using the existing `docker-run-docker-async`, since they don't need to update the tablist.

Tablist-generating actions can be implemented with `docker-run-async` but with a slightly more complicated callback.

**Limitations/Edge Cases**
Most docker commands act on multiple items, e.g. `docker container rm c1 c2 c3`, so I provide `docker-utils-generic-action-merged` than runs the commands on all selected items in a single process. There are a couple of commands which can act on a selection but the underlying command acts only on single items. For those I use the version of `docker-utils-generic-action-async` above which loops over selected items.

