### PR TITLE
Rename docker-utils-inspect -> docker-inspect

### DIFF
--- a/docker-core.el
+++ b/docker-core.el
@@ -80,7 +80,7 @@
   (--each (docker-utils-get-marked-items-ids)
     (docker-run-docker-async-with-buffer (s-split " " action) args it)))
 
-(aio-defun docker-utils-inspect ()
+(aio-defun docker-inspect ()
   "Docker Inspect the tablist entry under point."
   (interactive)
   (let* ((id (tabulated-list-get-id))


### PR DESCRIPTION
I think this was meant to be done in 442f22ce20a6570b7cc62ac553faa922d186afc0, but the function was not renamed.

Fixes `Wrong type argument: commandp, docker-inspect` due to the renamed keybind symbols.