### PR TITLE
Add option for whether to display docker status in transient buffer

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -127,22 +127,23 @@ displayed values in the column."
 (aio-defun docker-container-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :containers "Containers")
-  (let* ((entries (aio-await (docker-container-entries-propertized (docker-container-ls-arguments))))
-         (index (--find-index (string-equal "Status" (plist-get it :name)) docker-container-columns))
-         (statuses (--map (aref (cadr it) index) entries))
-         (faces (--map (get-text-property 0 'font-lock-face it) statuses))
-         (all (length faces))
-         (up (-count (-partial #'equal 'docker-face-status-up) faces))
-         (down (-count (-partial #'equal 'docker-face-status-down) faces))
-         (other (- all up down)))
-    (plist-put docker-status-strings
-               :containers
-               (format "Containers (%s total, %s up, %s down, %s other)"
-                       all
-                       (propertize (number-to-string up) 'face 'docker-face-status-up)
-                       (propertize (number-to-string down) 'face 'docker-face-status-down)
-                       (propertize (number-to-string other) 'face 'docker-face-status-other)))
-    (transient--redisplay)))
+  (when docker-display-status-in-transient
+    (let* ((entries (aio-await (docker-container-entries-propertized (docker-container-ls-arguments))))
+           (index (--find-index (string-equal "Status" (plist-get it :name)) docker-container-columns))
+           (statuses (--map (aref (cadr it) index) entries))
+           (faces (--map (get-text-property 0 'font-lock-face it) statuses))
+           (all (length faces))
+           (up (-count (-partial #'equal 'docker-face-status-up) faces))
+           (down (-count (-partial #'equal 'docker-face-status-down) faces))
+           (other (- all up down)))
+      (plist-put docker-status-strings
+                 :containers
+                 (format "Containers (%s total, %s up, %s down, %s other)"
+                         all
+                         (propertize (number-to-string up) 'face 'docker-face-status-up)
+                         (propertize (number-to-string down) 'face 'docker-face-status-down)
+                         (propertize (number-to-string other) 'face 'docker-face-status-other)))
+      (transient--redisplay))))
 
 (add-hook 'docker-open-hook #'docker-container-update-status-async)
 

--- a/docker-core.el
+++ b/docker-core.el
@@ -41,6 +41,11 @@
 (defvar docker-status-strings '(:containers "" :images "" :networks "" :volumes "")
   "Plist of statuses for `docker' transient.")
 
+(defcustom docker-display-status-in-transient t
+  "Whether to display docker status in the main transient buffer."
+  :group 'docker
+  :type 'boolean)
+
 (defun docker-run-docker-async (&rest args)
   "Execute \"`docker-command' ARGS\" and return a promise with the results."
   (apply #'docker-run-async docker-command (docker-arguments) args))

--- a/docker-image.el
+++ b/docker-image.el
@@ -150,14 +150,15 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-image-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :images "Images")
-  (let* ((entries (aio-await (docker-image-entries-propertized (docker-image-ls-arguments))))
-         (dangling (--filter (docker-image-dangling-p (car it)) entries)))
-    (plist-put docker-status-strings
-               :images
-               (format "Images (%s total, %s dangling)"
-                       (number-to-string (length entries))
-                       (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling)))
-    (transient--redisplay)))
+  (when docker-display-status-in-transient
+    (let* ((entries (aio-await (docker-image-entries-propertized (docker-image-ls-arguments))))
+           (dangling (--filter (docker-image-dangling-p (car it)) entries)))
+      (plist-put docker-status-strings
+                 :images
+                 (format "Images (%s total, %s dangling)"
+                         (number-to-string (length entries))
+                         (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling)))
+      (transient--redisplay))))
 
 (add-hook 'docker-open-hook #'docker-image-update-status-async)
 

--- a/docker-network.el
+++ b/docker-network.el
@@ -111,14 +111,15 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-network-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :networks "Networks")
-  (let* ((entries (aio-await (docker-network-entries-propertized (docker-network-ls-arguments))))
-         (dangling (--filter (docker-network-dangling-p (car it)) entries)))
-    (plist-put docker-status-strings
-               :networks
-               (format "Networks (%s total, %s dangling)"
-                       (number-to-string (length entries))
-                       (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling)))
-    (transient--redisplay)))
+  (when docker-display-status-in-transient
+    (let* ((entries (aio-await (docker-network-entries-propertized (docker-network-ls-arguments))))
+           (dangling (--filter (docker-network-dangling-p (car it)) entries)))
+      (plist-put docker-status-strings
+                 :networks
+                 (format "Networks (%s total, %s dangling)"
+                         (number-to-string (length entries))
+                         (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling)))
+      (transient--redisplay))))
 
 (add-hook 'docker-open-hook #'docker-network-update-status-async)
 

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -109,14 +109,15 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-volume-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :volumes "Volumes")
-  (let* ((entries (aio-await (docker-volume-entries-propertized (docker-volume-ls-arguments))))
-         (dangling (--filter (docker-volume-dangling-p (car it)) entries)))
-    (plist-put docker-status-strings
-               :volumes
-               (format "Volumes (%s total, %s dangling)"
-                       (number-to-string (length entries))
-                       (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling)))
-    (transient--redisplay)))
+  (when docker-display-status-in-transient
+    (let* ((entries (aio-await (docker-volume-entries-propertized (docker-volume-ls-arguments))))
+           (dangling (--filter (docker-volume-dangling-p (car it)) entries)))
+      (plist-put docker-status-strings
+                 :volumes
+                 (format "Volumes (%s total, %s dangling)"
+                         (number-to-string (length entries))
+                         (propertize (number-to-string (length dangling)) 'face 'docker-face-dangling)))
+      (transient--redisplay))))
 
 (add-hook 'docker-open-hook #'docker-volume-update-status-async)
 


### PR DESCRIPTION
This PR adds a toggle variable (`docker-display-status-in-transient`) for determining whether to display the status of Docker objects in the transient buffer.

Being able to disable the updates speeds up usage of the transient buffer, especially on a remote host via tramp. Also addresses hanging when running `docker` per #186 .