### PR TITLE
Allow Hiding of Docker Command Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Here is a list of other customizations you can set:
 | docker-run-as-root                | Runs docker as root when enabled       | `nil`                |
 | docker-volume-columns             | Columns definition for volumes         | Too complex to show  |
 | docker-volume-default-sort-key    | Sort key for volumes                   | `("Driver")`         |
-| docker-message-commands       | If non-nil message run docker commands | `t`                  |
+| docker-show-messages              | If non-nil message run docker commands | `t`                  |
 
 ### Changing the default arguments for `docker run`
 

--- a/README.md
+++ b/README.md
@@ -70,27 +70,28 @@ https://magit.vc/manual/transient/Enabling-and-Disabling-Suffixes.html for more 
 
 Here is a list of other customizations you can set:
 
-| Variable                          | Description                           | Default              |
-|-----------------------------------|---------------------------------------|----------------------|
-| docker-command                    | The docker binary to use              | `docker`             |
-| docker-compose-command            | The docker-compose binary to use      | `docker-compose`     |
-| docker-container-columns          | Columns definition for containers     | `/bin/sh`            |
-| docker-container-default-sort-key | Sort key for containers               | `("Image")`          |
-| docker-container-shell-file-name  | Shell to use when entering containers | `/bin/sh`            |
-| docker-image-columns              | Columns definition for images         | Too complex to show  |
-| docker-image-default-sort-key     | Sort key for images                   | `("Repository")`     |
-| docker-image-run-default-args     | Base arguments to use for docker run  | `("-i" "-t" "--rm")` |
-| docker-network-columns            | Columns definition for networks       | Too complex to show  |
-| docker-network-default-sort-key   | Sort key for networks                 | `("Name")`           |
-| docker-run-as-root                | Runs docker as root when enabled      | `nil`                |
-| docker-volume-columns             | Columns definition for volumes        | Too complex to show  |
-| docker-volume-default-sort-key    | Sort key for volumes                  | `("Driver")`         |
+| Variable                          | Description                            | Default              |
+|-----------------------------------|----------------------------------------|----------------------|
+| docker-command                    | The docker binary to use               | `docker`             |
+| docker-compose-command            | The docker-compose binary to use       | `docker-compose`     |
+| docker-container-columns          | Columns definition for containers      | `/bin/sh`            |
+| docker-container-default-sort-key | Sort key for containers                | `("Image")`          |
+| docker-container-shell-file-name  | Shell to use when entering containers  | `/bin/sh`            |
+| docker-image-columns              | Columns definition for images          | Too complex to show  |
+| docker-image-default-sort-key     | Sort key for images                    | `("Repository")`     |
+| docker-image-run-default-args     | Base arguments to use for docker run   | `("-i" "-t" "--rm")` |
+| docker-network-columns            | Columns definition for networks        | Too complex to show  |
+| docker-network-default-sort-key   | Sort key for networks                  | `("Name")`           |
+| docker-run-as-root                | Runs docker as root when enabled       | `nil`                |
+| docker-volume-columns             | Columns definition for volumes         | Too complex to show  |
+| docker-volume-default-sort-key    | Sort key for volumes                   | `("Driver")`         |
+| docker-message-commands       | If non-nil message run docker commands | `t`                  |
 
 ### Changing the default arguments for `docker run`
 
 You can match on the repository name for an image to customize the initial infix arguments via `docker-image-run-custom-args`:
 
-```elips
+```elisp
 (add-to-list
    'docker-image-run-custom-args
    `("^postgres" ("-e POSTGRES_PASSWORD=postgres" . ,docker-image-run-default-args)))

--- a/docker-process.el
+++ b/docker-process.el
@@ -36,6 +36,11 @@
   :group 'docker
   :type 'boolean)
 
+(defcustom docker-message-commands t
+  "If non-nil `message' docker commands which are run."
+  :group 'docker
+  :type 'boolean)
+
 (defmacro docker-with-sudo (&rest body)
   "Ensure `default-directory' is set correctly according to `docker-run-as-root' then execute BODY."
   (declare (indent defun))
@@ -49,7 +54,7 @@
   (docker-with-sudo
     (let* ((process-args (-remove 's-blank? (-flatten args)))
            (command (s-join " " (-insert-at 0 program process-args))))
-      (message "Running: %s" command)
+      (when docker-message-commands (message "Running: %s" command))
       (start-file-process-shell-command command (apply #'docker-utils-generate-new-buffer-name program process-args) command))))
 
 (defun docker-run-async (program &rest args)
@@ -91,7 +96,8 @@
       (aio-resolve promise
                    (lambda ()
                      (message nil)
-                     (message "Finished: %s" (process-name process))
+                     (when docker-message-commands
+                       (message "Finished: %s" (process-name process)))
                      (run-with-timer 2 nil (lambda () (message nil)))
                      (with-current-buffer (process-buffer process)
                        (prog1 (buffer-substring-no-properties (point-min) (point-max))

--- a/docker-process.el
+++ b/docker-process.el
@@ -36,7 +36,7 @@
   :group 'docker
   :type 'boolean)
 
-(defcustom docker-message-commands t
+(defcustom docker-show-messages t
   "If non-nil `message' docker commands which are run."
   :group 'docker
   :type 'boolean)
@@ -54,7 +54,7 @@
   (docker-with-sudo
     (let* ((process-args (-remove 's-blank? (-flatten args)))
            (command (s-join " " (-insert-at 0 program process-args))))
-      (when docker-message-commands (message "Running: %s" command))
+      (when docker-show-messages (message "Running: %s" command))
       (start-file-process-shell-command command (apply #'docker-utils-generate-new-buffer-name program process-args) command))))
 
 (defun docker-run-async (program &rest args)
@@ -96,7 +96,7 @@
       (aio-resolve promise
                    (lambda ()
                      (message nil)
-                     (when docker-message-commands
+                     (when docker-show-messages
                        (message "Finished: %s" (process-name process)))
                      (run-with-timer 2 nil (lambda () (message nil)))
                      (with-current-buffer (process-buffer process)


### PR DESCRIPTION
Hi, really liking the new async stuff, this is just a small PR which allows you to inhibit the messaging of run docker commands:

```elisp
(setq docker-message-commands nil)
```

The default it `t` so the default behaviour does not change.

Thanks!