### PR TITLE
Fix Byte Compile Warnings

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -235,13 +235,15 @@ nil, ask the user for it."
 (defun docker-container-vterm (container)
   "Open `vterm' in CONTAINER."
   (interactive (list (docker-container-read-name)))
-  (let* ((container-address (format "docker:%s:/" container))
-         (file-prefix (let ((prefix (file-remote-p default-directory)))
-                        (if prefix
-                            (format "%s|" (s-chop-suffix ":" prefix))
-                          "/")))
-         (default-directory (format "%s%s" file-prefix container-address)))
-    (vterm-other-window (docker-utils-generate-new-buffer-name "docker" "vterm:" default-directory))))
+  (if (fboundp 'vterm-other-window)
+      (let* ((container-address (format "docker:%s:/" container))
+             (file-prefix (let ((prefix (file-remote-p default-directory)))
+                            (if prefix
+                                (format "%s|" (s-chop-suffix ":" prefix))
+                              "/")))
+             (default-directory (format "%s%s" file-prefix container-address)))
+        (vterm-other-window (docker-utils-generate-new-buffer-name "docker" "vterm:" default-directory)))
+    (error "The vterm package is not installed")))
 
 (defun docker-container-cp-from-selection (container-path host-path)
   "Run \"docker cp\" from CONTAINER-PATH to HOST-PATH for selected container."

--- a/docker-process.el
+++ b/docker-process.el
@@ -41,6 +41,9 @@
   :group 'docker
   :type 'boolean)
 
+(defvar vterm-kill-buffer-on-exit)
+(defvar vterm-shell)
+
 (defmacro docker-with-sudo (&rest body)
   "Ensure `default-directory' is set correctly according to `docker-run-as-root' then execute BODY."
   (declare (indent defun))
@@ -82,10 +85,13 @@
 
 (defun docker-run-async-with-buffer-vterm (program &rest args)
   "Execute \"PROGRAM ARGS\" and display output in a new `vterm' buffer."
-  (let* ((process-args (-remove 's-blank? (-flatten args)))
-         (vterm-shell (s-join " " (-insert-at 0 program process-args)))
-         (vterm-kill-buffer-on-exit nil))
-    (vterm-other-window (apply #'docker-utils-generate-new-buffer-name program process-args))))
+  (if (fboundp 'vterm-other-window)
+      (let* ((process-args (-remove 's-blank? (-flatten args)))
+             (vterm-shell (s-join " " (-insert-at 0 program process-args)))
+             (vterm-kill-buffer-on-exit nil))
+        (vterm-other-window
+         (apply #'docker-utils-generate-new-buffer-name program process-args)))
+    (error "The vterm package is not installed")))
 
 (defun docker-process-sentinel (promise process event)
   "Sentinel that resolves the PROMISE using PROCESS and EVENT."


### PR DESCRIPTION
Hi, this PR fixes a few byte compile warnings I saw when installing the latest from melpa:

```elisp
In end of data:
docker-container.el:486:1:Warning: the function ‘vterm-other-window’ is not
    known to be defined.

In toplevel form:
docker-process.el:83:1:Warning: Unused lexical variable
    ‘vterm-kill-buffer-on-exit’
docker-process.el:83:1:Warning: Unused lexical variable ‘vterm-shell’

In end of data:
docker-process.el:109:1:Warning: the function ‘vterm-other-window’ is not
    known to be defined.
```

Thanks