### PR TITLE
Added docker-pop-to-buffer-action for specifying pop-to-buffer behavior

### DIFF
--- a/docker-core.el
+++ b/docker-core.el
@@ -41,6 +41,9 @@
 (defvar docker-status-strings '(:containers "" :images "" :networks "" :volumes "")
   "Plist of statuses for `docker' transient.")
 
+(defvar docker-pop-buffer-action nil
+  "Action to use internally when `docker-utils-pop-to-buffer' calls `pop-to-buffer'")
+
 (defcustom docker-show-status t
   "Whether to display docker status in the main transient buffer."
   :group 'docker

--- a/docker-core.el
+++ b/docker-core.el
@@ -41,7 +41,7 @@
 (defvar docker-status-strings '(:containers "" :images "" :networks "" :volumes "")
   "Plist of statuses for `docker' transient.")
 
-(defvar docker-pop-buffer-action nil
+(defvar docker-pop-to-buffer-action nil
   "Action to use internally when `docker-utils-pop-to-buffer' calls `pop-to-buffer'")
 
 (defcustom docker-show-status t

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -84,7 +84,7 @@ Execute BODY in a buffer named with the help of NAME."
    (if (file-remote-p default-directory)
        (with-parsed-tramp-file-name default-directory nil (concat name " - " host))
      name)
-   docker-pop-buffer-action))
+   docker-pop-to-buffer-action))
 
 (defun docker-utils-unit-multiplier (str)
   "Return the correct multiplier for STR."

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -83,7 +83,8 @@ Execute BODY in a buffer named with the help of NAME."
   (pop-to-buffer
    (if (file-remote-p default-directory)
        (with-parsed-tramp-file-name default-directory nil (concat name " - " host))
-     name)))
+     name)
+   docker-pop-buffer-action))
 
 (defun docker-utils-unit-multiplier (str)
   "Return the correct multiplier for STR."


### PR DESCRIPTION
.This value is passed as ACTION to the internal call to pop-to-buffer

Specifically this makes it possible to influence the way that Docker.el ends up splitting/choosing windows.