### PR TITLE
Docker move profile flag

### DIFF
--- a/docker-compose.el
+++ b/docker-compose.el
@@ -283,6 +283,7 @@
    ("h" "Host" "--host " read-string)
    ("l" "Log level" "--log-level " docker-compose-read-log-level)
    ("p" "Project name" "--project-name " read-string)
+   ("r" "Profile" "--profile " read-string)
    ("v" "Verbose" "--verbose")]
   [["Images"
     ("B" "Build"      docker-compose-build)


### PR DESCRIPTION
The --profile flag is a global option for the `docker-compose` command. Therefore it is removed from `docker-compose-down` and `docker-compose-up` and moved to the `docker-compose` transient prefix. 