### PR TITLE
Allow eldev to Fetch Packages from gnu-elpa

### DIFF
--- a/Eldev
+++ b/Eldev
@@ -1,3 +1,4 @@
 ; -*- mode: emacs-lisp; lexical-binding: t; no-byte-compile: t -*-
 
 (eldev-use-package-archive 'melpa)
+(eldev-use-package-archive 'gnu-elpa)


### PR DESCRIPTION
I think this should fix the ci errors.  transient now depends on `compat` which is not on melpa (but on gnu elpa) so `(eldev-use-package-archive 'gnu-elpa)` just allows eldev to fetch deps from elpa.

Thanks!

Edit: looks good, ci passed