### PR TITLE
add aio-wait-for to *-read-name functions

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -155,7 +155,7 @@ string that transforms the displayed values in the column."
 
 (defun docker-container-read-name ()
   "Read an container name."
-  (completing-read "Container: " (-map #'car (docker-container-entries))))
+  (completing-read "Container: " (-map #'car (aio-wait-for (docker-container-entries)))))
 
 (defvar eshell-buffer-name)
 

--- a/docker-image.el
+++ b/docker-image.el
@@ -170,7 +170,7 @@ The result is the tabulated list id for an entry is propertized with
 
 (defun docker-image-read-name ()
   "Read an image name."
-  (completing-read "Image: " (-map #'car (docker-image-entries))))
+  (completing-read "Image: " (-map #'car (aio-wait-for (docker-image-entries)))))
 
 ;;;###autoload (autoload 'docker-image-pull-one "docker-image" nil t)
 (aio-defun docker-image-pull-one (name &optional all)

--- a/docker-network.el
+++ b/docker-network.el
@@ -132,7 +132,7 @@ The result is the tabulated list id for an entry is propertized with
 
 (defun docker-network-read-name ()
   "Read a network name."
-  (completing-read "Network: " (-map #'car (docker-network-entries))))
+  (completing-read "Network: " (-map #'car (aio-wait-for (docker-network-entries)))))
 
 (defun docker-network-mark-dangling ()
   "Mark only the dangling networks listed in *docker-networks*.

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -130,7 +130,7 @@ The result is the tabulated list id for an entry is propertized with
 
 (defun docker-volume-read-name ()
   "Read a volume name."
-  (completing-read "Volume: " (-map #'car (docker-volume-entries))))
+  (completing-read "Volume: " (-map #'car (aio-wait-for (docker-volume-entries)))))
 
 ;;;###autoload (autoload 'docker-volume-dired "docker-volume" nil t)
 (aio-defun docker-volume-dired (name)


### PR DESCRIPTION
Hello, this PR fixes a problem of having an empty list of e.g. containers in `docker-container-shell` command.
