### PR TITLE
Remove json-mode requirement

### DIFF
--- a/docker-utils.el
+++ b/docker-utils.el
@@ -28,7 +28,7 @@
 (require 'dash)
 (require 'tramp)
 (require 'tablist)
-(require 'json-mode)
+(require 'json)
 (require 'transient)
 
 (defun docker-utils-get-marked-items-ids ()

--- a/docker.el
+++ b/docker.el
@@ -4,7 +4,7 @@
 ;; URL: https://github.com/Silex/docker.el
 ;; Keywords: filename, convenience
 ;; Version: 2.1.1
-;; Package-Requires: ((aio "1.0") (dash "2.19.1") (docker-tramp "0.1") (emacs "26.1") (json-mode "1.8.0") (s "1.12.0") (tablist "1.0") (transient "0.3.7"))
+;; Package-Requires: ((aio "1.0") (dash "2.19.1") (docker-tramp "0.1") (emacs "26.1") (s "1.12.0") (tablist "1.0") (transient "0.3.7"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
`json-mode` is listed as a requirement of this package but it's not needed. The only one file that requires doesn't use it, `json-read-from-string` call comes from the `json` built-in package, not `json-mode`. This PR removes this redundant depenendency.