### PR TITLE
Remove docker-tramp dependency

### DIFF
--- a/docker.el
+++ b/docker.el
@@ -4,7 +4,7 @@
 ;; URL: https://github.com/Silex/docker.el
 ;; Keywords: filename, convenience
 ;; Version: 2.2.0
-;; Package-Requires: ((aio "1.0") (dash "2.19.1") (docker-tramp "0.1") (emacs "26.1") (s "1.12.0") (tablist "1.0") (transient "0.3.7"))
+;; Package-Requires: ((aio "1.0") (dash "2.19.1") (emacs "26.1") (s "1.12.0") (tablist "1.0") (transient "0.3.7"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This package is now deprecated and will be available from the tramp-container package bundled with Emacs.

https://github.com/emacs-mirror/emacs/blob/master/lisp/net/tramp-container.el