### PR TITLE
fix: `docker-volume-dired` cannot open directory

### DIFF
--- a/docker-volume.el
+++ b/docker-volume.el
@@ -136,7 +136,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-volume-dired (name)
   "Enter `dired' in the volume named NAME."
   (interactive (list (docker-volume-read-name)))
-  (let ((path (aio-await (docker-run-docker-async "inspect" "-f" "\"{{ .Mountpoint }}\"" name))))
+  (let ((path (s-trim-right (aio-await (docker-run-docker-async "inspect" "-f" "\"{{ .Mountpoint }}\"" name))))
     (dired (format "/sudo::%s" path))))
 
 (defun docker-volume-dired-selection ()


### PR DESCRIPTION
I found an issue with `docker-volume-dired` where I couldn't view files inside a volume using `dired`. 
The problem was that there was a newline character at the end of the output from `docker inspect`, and this value was passed to `dired` which resulted in it not recognizing it as the correct path. 

In this pull request, I removed the newline character from the output of `docker inspect` and fixed it so that `dired` works correctly.