### PR TITLE
Update default docker compose command

### DIFF
--- a/docker-compose.el
+++ b/docker-compose.el
@@ -36,7 +36,7 @@
   "Docker compose customization group."
   :group 'docker)
 
-(defcustom docker-compose-command "docker-compose"
+(defcustom docker-compose-command "docker compose"
   "The `docker-compose' binary."
   :group 'docker-compose
   :type 'string)


### PR DESCRIPTION
Replace deprecated "docker-compose" with "docker compose" in docker.el. This change reflects that docker compose is now a built-in Docker plugin, and the standalone docker-compose binary is no longer maintained [1].

[1] https://docs.docker.com/compose/releases/migrate/