### PR TITLE
Replace ElDev with Eask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
         if: ${{ matrix.melpa_version == 'stable' }}
         run: eask source delete melpa; eask source add melpa-stable
       - name: Install dependencies
-        run: eask install-deps
+        run: eask install-deps --dev; eask uninstall docker
       - name: Test byte compilation against MELPA ${{ matrix.melpa_version }}
         run: eask compile --strict --debug -v 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,14 @@ jobs:
           - stable
           - unstable
 
+    container: silex/emacs:${{ matrix.emacs_version }}-ci-eask
     steps:
-    - name: Set up Emacs
-      uses: purcell/setup-emacs@master
-      with:
-        version: ${{ matrix.emacs_version }}
-
-    - name: Install Eldev
-      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
-
-    - name: Check out the source code
-      uses: actions/checkout@main
-
-    - name: Test byte compilation against MELPA ${{ matrix.melpa_version }}
-      run: eldev -dtT -C --${{ matrix.melpa_version }} compile --warnings-as-errors
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set package source
+        if: ${{ matrix.melpa_version == 'stable' }}
+        run: eask source delete melpa; eask source add melpa-stable
+      - name: Install dependencies
+        run: eask install-deps
+      - name: Test byte compilation against MELPA ${{ matrix.melpa_version }}
+        run: eask compile --strict --debug -v 5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-/Eldev-local
-/.eldev
+/.eask

--- a/Eask
+++ b/Eask
@@ -1,0 +1,20 @@
+(package "docker"
+         "2.3.1"
+         "Interface to Docker")
+
+(website-url "https://github.com/Silex/docker.el")
+(keywords "filename" "convenience")
+
+(package-file "docker.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source "gnu")
+(source "melpa")
+
+(depends-on "emacs"     "26.1")
+(depends-on "aio"       "1.0")
+(depends-on "dash"      "2.19.1")
+(depends-on "s"         "1.13.0")
+(depends-on "tablist"   "1.1")
+(depends-on "transient" "0.4.3")

--- a/Eask
+++ b/Eask
@@ -18,3 +18,7 @@
 (depends-on "s"         "1.13.0")
 (depends-on "tablist"   "1.1")
 (depends-on "transient" "0.4.3")
+;; hack: this forces the built-in transient to be upgraded to latest.
+;; make sure to run "eask uninstall docker" in CI to avoid confusing the versions of docker.el
+(development
+ (depends-on "docker"))

--- a/Eldev
+++ b/Eldev
@@ -1,7 +1,0 @@
-; -*- mode: emacs-lisp; lexical-binding: t; no-byte-compile: t -*-
-
-(eldev-use-package-archive 'melpa)
-(eldev-use-package-archive 'gnu-elpa)
-
-(with-eval-after-load 'bytecomp
-  (setf byte-compile-warnings '(not docstrings)))

--- a/docker-compose.el
+++ b/docker-compose.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker-container.el
+++ b/docker-container.el
@@ -23,6 +23,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker-context.el
+++ b/docker-context.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker-core.el
+++ b/docker-core.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 'aio)
 (require 'transient)

--- a/docker-faces.el
+++ b/docker-faces.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'dash)

--- a/docker-group.el
+++ b/docker-group.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (defgroup docker nil
   "Docker customization group."

--- a/docker-image.el
+++ b/docker-image.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker-network.el
+++ b/docker-network.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker-process.el
+++ b/docker-process.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker-utils.el
+++ b/docker-utils.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -22,6 +22,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 's)
 (require 'aio)

--- a/docker.el
+++ b/docker.el
@@ -28,6 +28,8 @@
 ;; This package allows you to manipulate docker images, containers & more from Emacs.
 
 ;;; Code:
+(eval-when-compile
+  (setq-local byte-compile-warnings '(not docstrings)))
 
 (require 'docker-compose)
 (require 'docker-container)


### PR DESCRIPTION
Closes #243

As you can see from the diffs, the replacement is quite straightforward. I like Eask because of all the tools it allows you to bootstrap with a single command. Also the dev is quite active.

Looks like the successful action's running time went from 1m 40s down to 1m using Eask. 

## Changes
- use `silex/emacs:ver-ci-eask` image to cut out an install step
- move `byte-compile-warnings` setting from eldev file to all files
  Eask doesn't have a script preamble file like eldev, but I think putting this in each file is cleaner as it silences the warnings for 
  users too.

## Examples
- [failing run](https://github.com/joshbax189/docker.el/actions/runs/13822407029/job/38670617702#step:6:100)
  Shows `--debug` stack trace.

## Questions/Extra Comments

On the `hack`:
This is due to a quirk in `package-install`. It seems to ignore built-in packages when explicitly requested (e.g. `(package-install 'transient)` does nothing), but does upgrade built-in packages when they are dependencies (e.g. `(package-install 'docker)` triggers an upgrade of built in `transient`).

This was an issue for emacs 28, which has transient 0.3.7 built in.

Adding `docker` itself as a dependency (scoped to develop) and then manually uninstalling it leaves the environment intact. Since the dependencies are resolved by `package.el` anyway, the resulting installed dependencies match what we would expect by following the dependencies in the Eask file.

In my opinion, the packages in `depends-on` _should_ override the built-in packages so that the environment does match what you would get by running `(package-install 'docker)`. I'll make an issue for that in the Eask repo.

Let me know if there are any workflows from eldev that you use and I can find the Eask equivalent and maybe add them to the readme.

Cheers!