### PR TITLE
option to disable docker-show-status in remote buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Here is a list of other customizations you can set:
 | docker-run-as-root                    | Runs docker as root when enabled           | `nil`                |
 | docker-run-async-with-buffer-function | Function used to run programs with buffers | Too complex to show  |
 | docker-show-messages                  | If non-nil message docker commands         | `t`                  |
-| docker-show-status                    | If non-nil compute status                  | `t`                  |
+| docker-show-status                    | When to compute status                     | `non-remote`                  |
 | docker-volume-columns                 | Columns definition for volumes             | Too complex to show  |
 | docker-volume-default-sort-key        | Sort key for volumes                       | `("Driver")`         |
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Here is a list of other customizations you can set:
 | docker-run-as-root                    | Runs docker as root when enabled           | `nil`                |
 | docker-run-async-with-buffer-function | Function used to run programs with buffers | Too complex to show  |
 | docker-show-messages                  | If non-nil message docker commands         | `t`                  |
-| docker-show-status                    | When to compute status                     | `non-remote`                  |
+| docker-show-status                    | When to compute status                     | `local-only`         |
 | docker-volume-columns                 | Columns definition for volumes             | Too complex to show  |
 | docker-volume-default-sort-key        | Sort key for volumes                       | `("Driver")`         |
 

--- a/docker-container.el
+++ b/docker-container.el
@@ -135,7 +135,7 @@ string that transforms the displayed values in the column."
 (aio-defun docker-container-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :containers "Containers")
-  (when docker-show-status
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-container-entries-propertized (docker-container-ls-arguments))))
            (index (--find-index (string-equal "Status" (plist-get it :name)) docker-container-columns))
            (statuses (--map (aref (cadr it) index) entries))

--- a/docker-container.el
+++ b/docker-container.el
@@ -135,7 +135,7 @@ string that transforms the displayed values in the column."
 (aio-defun docker-container-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :containers "Containers")
-  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'local-only) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-container-entries-propertized (docker-container-ls-arguments))))
            (index (--find-index (string-equal "Status" (plist-get it :name)) docker-container-columns))
            (statuses (--map (aref (cadr it) index) entries))

--- a/docker-context.el
+++ b/docker-context.el
@@ -120,7 +120,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-context-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :contexts "Contexts")
-  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'local-only) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-context-entries-propertized (docker-context-ls-arguments)))))
       (plist-put docker-status-strings
                  :contexts

--- a/docker-context.el
+++ b/docker-context.el
@@ -120,7 +120,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-context-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :contexts "Contexts")
-  (when docker-show-status
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-context-entries-propertized (docker-context-ls-arguments)))))
       (plist-put docker-status-strings
                  :contexts

--- a/docker-core.el
+++ b/docker-core.el
@@ -43,12 +43,12 @@
 (defvar docker-status-strings '(:containers "" :images "" :networks "" :volumes "" :contexts "")
   "Plist of statuses for `docker' transient.")
 
-(defcustom docker-show-status 'non-remote
+(defcustom docker-show-status 'local-only
   "Whether to display docker status in the main transient buffer."
   :group 'docker
   :type '(choice
           (const :tag "Always" t)
-          (const :tag "Non-remote" non-remote)
+          (const :tag "Local Only" local-only)
           (const :tag "Never" nil)))
 
 (defun docker-run-docker-async (&rest args)

--- a/docker-core.el
+++ b/docker-core.el
@@ -43,10 +43,13 @@
 (defvar docker-status-strings '(:containers "" :images "" :networks "" :volumes "" :contexts "")
   "Plist of statuses for `docker' transient.")
 
-(defcustom docker-show-status t
+(defcustom docker-show-status 'non-remote
   "Whether to display docker status in the main transient buffer."
   :group 'docker
-  :type 'boolean)
+  :type '(choice
+          (const :tag "Always" t)
+          (const :tag "Non-remote" non-remote)
+          (const :tag "Never" nil)))
 
 (defun docker-run-docker-async (&rest args)
   "Execute \"`docker-command' ARGS\" and return a promise with the results."

--- a/docker-image.el
+++ b/docker-image.el
@@ -153,7 +153,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-image-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :images "Images")
-  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'local-only) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-image-entries-propertized (docker-image-ls-arguments))))
            (dangling (--filter (docker-image-dangling-p (car it)) entries)))
       (plist-put docker-status-strings

--- a/docker-image.el
+++ b/docker-image.el
@@ -153,7 +153,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-image-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :images "Images")
-  (when docker-show-status
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-image-entries-propertized (docker-image-ls-arguments))))
            (dangling (--filter (docker-image-dangling-p (car it)) entries)))
       (plist-put docker-status-strings

--- a/docker-network.el
+++ b/docker-network.el
@@ -115,7 +115,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-network-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :networks "Networks")
-  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'local-only) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-network-entries-propertized (docker-network-ls-arguments))))
            (dangling (--filter (docker-network-dangling-p (car it)) entries)))
       (plist-put docker-status-strings

--- a/docker-network.el
+++ b/docker-network.el
@@ -115,7 +115,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-network-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :networks "Networks")
-  (when docker-show-status
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-network-entries-propertized (docker-network-ls-arguments))))
            (dangling (--filter (docker-network-dangling-p (car it)) entries)))
       (plist-put docker-status-strings

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -113,7 +113,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-volume-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :volumes "Volumes")
-  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'local-only) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-volume-entries-propertized (docker-volume-ls-arguments))))
            (dangling (--filter (docker-volume-dangling-p (car it)) entries)))
       (plist-put docker-status-strings

--- a/docker-volume.el
+++ b/docker-volume.el
@@ -113,7 +113,7 @@ The result is the tabulated list id for an entry is propertized with
 (aio-defun docker-volume-update-status-async ()
   "Write the status to `docker-status-strings'."
   (plist-put docker-status-strings :volumes "Volumes")
-  (when docker-show-status
+  (when (or (eq docker-show-status t) (and (eq docker-show-status 'non-remote) (not (file-remote-p default-directory))))
     (let* ((entries (aio-await (docker-volume-entries-propertized (docker-volume-ls-arguments))))
            (dangling (--filter (docker-volume-dangling-p (car it)) entries)))
       (plist-put docker-status-strings


### PR DESCRIPTION
Addresses the suggestion made in https://github.com/Silex/docker.el/issues/186 (the last comment), but maybe doesn't exactly fix the root issue. 

I had this as an advice for a while, but figured I'd try to upstream it