### PR TITLE
Add read-only buffer support and smart streaming for Docker logs

### DIFF
--- a/docker-container.el
+++ b/docker-container.el
@@ -432,7 +432,7 @@ default directory set to workdir."
    ("n" "No STDIN" "--no-stdin")
    ("d" "Key sequence for detaching" "--detach-keys " read-string)]
   [:description docker-generic-action-description
-   ("a" "Attach" docker-generic-action-with-buffer)])
+   ("a" "Attach" docker-generic-action-with-buffer-stream)])
 
 (docker-utils-transient-define-prefix docker-container-cp ()
   "Transient for copying files from/to containers."
@@ -461,6 +461,15 @@ default directory set to workdir."
   [:description docker-generic-action-description
    ("K" "Kill" docker-generic-action-multiple-ids)])
 
+(defun docker-container-logs-action (action args)
+  "Show container logs, streaming if -f flag is present, otherwise collect then display.
+ACTION is the docker action, ARGS are the transient arguments."
+  (interactive (list (docker-get-transient-action)
+                     (transient-args transient-current-command)))
+  (if (member "-f" args)
+      (docker-generic-action-with-buffer-stream action args)
+    (aio-wait-for (docker-generic-action-with-buffer action args))))
+
 (docker-utils-transient-define-prefix docker-container-logs ()
   "Transient for showing containers logs."
   :man-page "docker-container-logs"
@@ -470,7 +479,7 @@ default directory set to workdir."
    ("t" "Tail" "--tail " read-string)
    ("u" "Until" "--until " read-string)]
   [:description docker-generic-action-description
-   ("L" "Logs" docker-generic-action-with-buffer)])
+   ("L" "Logs" docker-container-logs-action)])
 
 (docker-utils-define-transient-arguments docker-container-ls)
 

--- a/docker-container.el
+++ b/docker-container.el
@@ -467,7 +467,7 @@ ACTION is the docker action, ARGS are the transient arguments."
   (interactive (list (docker-get-transient-action)
                      (transient-args transient-current-command)))
   (if (member "-f" args)
-      (docker-generic-action-with-buffer-stream action args)
+      (docker-generic-action-with-buffer-stream action args t)
     (aio-wait-for (docker-generic-action-with-buffer action args))))
 
 (docker-utils-transient-define-prefix docker-container-logs ()

--- a/docker-core.el
+++ b/docker-core.el
@@ -60,9 +60,10 @@
   "Execute \"`docker-command' ARGS\" and return a promise with the results."
   (apply #'docker-run-async docker-command (docker-arguments) args))
 
-(defun docker-run-docker-async-with-buffer (&rest args)
-  "Execute \"`docker-command' ARGS\" and display the results in a buffer."
-  (apply #'docker-run-async-with-buffer docker-command (docker-arguments) args))
+(defun docker-run-docker-async-with-buffer (readonly &rest args)
+  "Execute \"`docker-command' ARGS\" and display the results in a buffer.
+If READONLY is non-nil, use a read-only buffer with ANSI color support."
+  (apply #'docker-run-async-with-buffer docker-command readonly (docker-arguments) args))
 
 (defun docker-get-transient-action ()
   "Extract the action out of `transient-current-command'."
@@ -91,13 +92,14 @@
   (aio-await (docker-run-docker-async action args (docker-utils-get-marked-items-ids)))
   (tablist-revert))
 
-(defun docker-generic-action-with-buffer-stream (action args)
+(defun docker-generic-action-with-buffer-stream (action args &optional readonly)
   "Run \"`docker-command' ACTION ARGS\" and print output to a new buffer.
-This uses a streaming shell buffer, suitable for interactive or long-running commands."
+This uses a streaming shell buffer, suitable for interactive or long-running commands.
+If READONLY is non-nil, use a read-only buffer with ANSI color support."
   (interactive (list (docker-get-transient-action)
                      (transient-args transient-current-command)))
   (--each (docker-utils-get-marked-items-ids)
-    (docker-run-docker-async-with-buffer (s-split " " action) args it)))
+    (docker-run-docker-async-with-buffer readonly (s-split " " action) args it)))
 
 (aio-defun docker-generic-action-with-buffer (action args)
   "Run \"`docker-command' ACTION ARGS\", wait for completion, then display output.


### PR DESCRIPTION
# Problem Statement

When viewing the logs of a container that had very long outputs (in non-follow mode), it would take 30s for the logs to fully populate the buffer. That in comparison with running it in my cli which takes 0.2 seconds. So I decided to dig in and fix this issue.

# Solution
- create two different modes for populating output buffers, streaming and non-streaming
- docker logs now behaves intelligently: read-only streams with -f, otherwise collects output first and displays in a buffer all at once. This is much faster.
- docker attach uses streaming mode as expected for interactive use
- Output is properly rendered with ANSI colors and stripped of carriage returns

# Changes
## docker-process.el:
- Add readonly parameter to docker-run-async-with-buffer functions
- Create docker-process-filter-readonly for read-only streaming buffers with ANSI color support and CR stripping
- Update shell and vterm buffer functions to support readonly mode (vterm falls back to shell when readonly)
## docker-core.el:
- Split buffer actions into docker-generic-action-with-buffer-stream (streaming) and docker-generic-action-with-buffer (collect-then-display)
- The collect-then-display variant waits for command completion before showing output in a special-mode buffer
## docker-container.el:
- Add docker-container-logs-action that intelligently chooses streaming vs collected output based on -f flag
- Update docker-container-attach to use streaming buffer for interactive use
- Update docker-container-logs to use the new smart logs action